### PR TITLE
feat: add cri-dockerd (wip)

### DIFF
--- a/nix/modules/virtualisation/cri-dockerd.nix
+++ b/nix/modules/virtualisation/cri-dockerd.nix
@@ -1,0 +1,60 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.virtualisation.cri-dockerd;
+  cri-dockerd = (import ../../pkgs/cri-dockerd/default.nix) pkgs;
+in
+  with lib; {
+    options.virtualisation.cri-dockerd = with types; {
+      enable = mkEnableOption "cri-dockerd container runtime";
+    };
+    config = mkIf cfg.enable {
+      environment.systemPackages = [cri-dockerd];
+
+      systemd.services.cri-docker = {
+        description = "CRI Interface for Docker Application Container Engine";
+        wantedBy = ["multi-user.target"];
+        after = ["network.target" "cri-docker.socket"];
+        requires = ["cri-docker.socket"];
+        serviceConfig = {
+          Type = "notify";
+          ExecStart = [
+            ""
+            ''
+              ${cri-dockerd}/bin/cri-dockerd \
+                --container-runtime-endpoint fd://
+            ''
+          ];
+          ExecReload = [
+            ""
+            "${pkgs.procps}/bin/kill -s HUP $MAINPID"
+          ];
+          TimeoutSec = 0;
+          RestartSec = 2;
+          Restart = "always";
+          StartLimitBurst = 3;
+          LimitNOFILE = "infinity";
+          LimitNPROC = "infinity";
+          LimitCORE = "infinity";
+          TasksMax = "infinity";
+          Delegate = "yes";
+          KillMode = "process";
+        };
+        path = with pkgs; [cri-dockerd iptables cni-plugins cni-plugin-flannel conntrack-tools util-linux];
+      };
+      systemd.sockets.cri-docker = {
+        description = "CRI Docker Socket for the API";
+        wantedBy = ["sockets.target"];
+        partOf = ["cri-docker.service"];
+        socketConfig = {
+          ListenStream = "%t/cri-dockerd.sock";
+          SocketMode = "0660";
+          SocketUser = "root";
+          SocketGroup = "docker";
+        };
+      };
+    };
+  }

--- a/nix/pkgs/cri-dockerd/default.nix
+++ b/nix/pkgs/cri-dockerd/default.nix
@@ -1,0 +1,29 @@
+{
+  fetchFromGitHub,
+  buildGoModule,
+  cni-plugins,
+  ...
+}:
+buildGoModule rec {
+  pname = "cri-dockerd";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Mirantis";
+    repo = "cri-dockerd";
+    rev = "v${version}";
+    sha256 = "kjHSws47t5NinlgVBtdJlyf+3aB0f2payDXloXyTehY=";
+  };
+  vendorHash = null;
+
+  postPatch = ''
+    sed -i -e 's|/opt/cni/bin|${cni-plugins}/bin|g' cmd/cri/options/options.go
+    sed -i -e 's|/opt/cni/bin|${cni-plugins}/bin|g' network/kubenet/kubenet_linux.go
+  '';
+
+  postInstall = ''
+    install -D $src/packaging/systemd/* -t $out/systemd/system
+  '';
+
+  doCheck = false;
+}


### PR DESCRIPTION
The command, `minikube start --driver none` needs this module but it raises an error below.

```
❯ minikube start --driver none
😄  minikube v1.28.0 on Nixos 23.05 (Stoat) (amd64)
    ▪ MINIKUBE_WANTUPDATENOTIFICATION=false
✨  Using the none driver based on existing profile
👍  Starting control plane node minikube in cluster minikube
🏃  Updating the running none "minikube" bare metal machine ...
ℹ️  OS release is NixOS 23.05 (Stoat)
🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.21 ...

❌  Exiting due to K8S_INSTALL_FAILED: updating control plane: copy: mkdir: sudo mkdir -p /etc/systemd/system/kubelet.service.d /lib/systemd/system /var/tmp/minikube: exit status 1
stdout:

stderr:
mkdir: cannot create directory ‘/etc/systemd/system/kubelet.service.d’: Read-only file system


╭───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                           │
│    😿  If the above advice does not help, please let us know:                             │
│    👉  https://github.com/kubernetes/minikube/issues/new/choose                           │
│                                                                                           │
│    Please run `minikube logs --file=logs.txt` and attach logs.txt to the GitHub issue.    │
│                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────╯


```