### PR TITLE
fix:remove a duplicated declaration of `package.nix`

### DIFF
--- a/nix/nix/default.nix
+++ b/nix/nix/default.nix
@@ -1,6 +1,5 @@
 {pkgs, ...}: {
   nix = {
-    package = pkgs.nix;
     settings = {
       auto-optimise-store = true;
       cores = 4;

--- a/nix/nix/default.nix
+++ b/nix/nix/default.nix
@@ -1,5 +1,6 @@
-{pkgs, ...}: {
+{pkgs, lib, ...}: {
   nix = {
+    package = lib.mkDefault pkgs.nix;
     settings = {
       auto-optimise-store = true;
       cores = 4;


### PR DESCRIPTION
fix #28 