### PR TITLE
ci: add dix diff workflow for configuration changes visibility

### DIFF
--- a/.github/workflows/pr-dix-diff.yml
+++ b/.github/workflows/pr-dix-diff.yml
@@ -1,0 +1,59 @@
+name: PR Dix Diff
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  dix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup-nix
+        with:
+          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Install dix
+        run: nix profile install nixpkgs#dix
+      - name: Run dix for all hosts
+        id: dix
+        run: |
+          {
+            echo 'DIFF_OUTPUT<<EOF'
+            echo '# Configuration Diff'
+            echo ''
+
+            echo '## NixOS Configurations'
+            for host in kilimanjaro manyara serengeti arusha; do
+              echo "### $host"
+              echo '```'
+              dix \
+                "$(nix path-info --derivation "github:natsukium/dotfiles#nixosConfigurations.$host.config.system.build.toplevel")" \
+                "$(nix path-info --derivation ".#nixosConfigurations.$host.config.system.build.toplevel")" \
+                || echo "Failed to generate diff"
+              echo '```'
+              echo ''
+            done
+
+            echo '## Darwin Configurations'
+            for host in katavi mikumi work; do
+              echo "### $host"
+              echo '```'
+              dix \
+                "$(nix path-info --derivation "github:natsukium/dotfiles#darwinConfigurations.$host.system")" \
+                "$(nix path-info --derivation ".#darwinConfigurations.$host.system")" \
+                || echo "Failed to generate diff"
+              echo '```'
+              echo ''
+            done
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: dix
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          message: ${{ steps.dix.outputs.DIFF_OUTPUT }}


### PR DESCRIPTION
Adds GitHub Actions workflow to automatically generate and post configuration diffs on pull requests using dix tool, helping reviewers understand the impact of changes across all NixOS and Darwin configurations.