### PR TITLE
chore: migrate to upstream API renames

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -108,7 +108,7 @@ in
       {
         checks =
           let
-            currentSystemConfigurations = lib.filterAttrs (k: v: v.pkgs.system == system) (
+            currentSystemConfigurations = lib.filterAttrs (k: v: v.pkgs.stdenv.hostPlatform.system == system) (
               flake.nixosConfigurations // flake.darwinConfigurations
             );
           in

--- a/modules/home/coding-agents/claude-code/default.nix
+++ b/modules/home/coding-agents/claude-code/default.nix
@@ -128,13 +128,13 @@ in
         };
       };
 
-      memory.source = ../common/AGENTS.md;
+      context = ../common/AGENTS.md;
 
       agentsDir = ./agents;
 
       commandsDir = ./commands;
 
-      skillsDir = ../common/skills;
+      skills = ../common/skills;
 
       lspServers = {
         nix = {

--- a/modules/home/coding-agents/opencode/default.nix
+++ b/modules/home/coding-agents/opencode/default.nix
@@ -22,7 +22,9 @@ in
         instructions = [ "CLAUDE.md" ];
 
         autoupdate = false;
+      };
 
+      tui = {
         theme = "nord";
       };
     };

--- a/pkgs/neovim-with-config/default.nix
+++ b/pkgs/neovim-with-config/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   neovim-unwrapped,
-  neovimUtils,
   vimPlugins,
   wrapNeovimUnstable,
 
@@ -103,22 +102,19 @@ let
     (lib.makeBinPath (language-servers ++ tools))
   ];
 
-  config = neovimUtils.makeNeovimConfig {
-    withNodeJs = true; # for copilot
-    withRuby = false;
-    withPython3 = false;
-    vimAlias = true;
-    customLuaRC = ''
-      vim.opt.rtp:prepend('${./.}')
-
-      ${builtins.readFile ./init.lua}
-    '';
-
-    plugins = import ./plugins.nix { inherit vimPlugins; };
-
-  };
 in
-(wrapNeovimUnstable neovim-unwrapped' (
-  # if wrapperArgs is defined directly in config, it will somehow be overwritten
-  config // { wrapperArgs = config.wrapperArgs ++ extraWrapperArgs; }
-))
+wrapNeovimUnstable neovim-unwrapped' {
+  withNodeJs = true; # for copilot
+  withRuby = false;
+  withPython3 = false;
+  vimAlias = true;
+  luaRcContent = ''
+    vim.opt.rtp:prepend('${./.}')
+
+    ${builtins.readFile ./init.lua}
+  '';
+
+  plugins = import ./plugins.nix { inherit vimPlugins; };
+
+  wrapperArgs = extraWrapperArgs;
+}

--- a/systems/nixos/arusha/default.nix
+++ b/systems/nixos/arusha/default.nix
@@ -15,14 +15,14 @@
     enable32Bit = true;
   };
 
-  virtualisation.docker = {
-    enable = true;
-    enableNvidia = true;
-  };
+  virtualisation.docker.enable = true;
 
-  # docker.enableNvidia enables nvidia-container-toolkit, which added an assertion
-  # requiring explicit driver configuration. On WSL, drivers come from Windows.
-  hardware.nvidia-container-toolkit.suppressNvidiaDriverAssertion = true;
+  # nvidia-container-toolkit added an assertion requiring explicit driver
+  # configuration. On WSL, drivers come from Windows.
+  hardware.nvidia-container-toolkit = {
+    enable = true;
+    suppressNvidiaDriverAssertion = true;
+  };
 
   fonts.packages = with pkgs; [
     noto-fonts-cjk-sans


### PR DESCRIPTION
## Summary
- Follow option renames in home-manager modules (claude-code, opencode)
- Refactor neovim wrapper to the current `wrapNeovimUnstable` calling convention
- Replace removed `virtualisation.docker.enableNvidia` with `hardware.nvidia-container-toolkit.enable` on arusha
- Use `stdenv.hostPlatform.system` instead of the legacy `pkgs.system` alias

All commits are intended to be pure API migrations — the resulting system closures should be byte-identical. Relying on the PR Dix Diff workflow to confirm.

## Test plan
- [ ] PR Dix Diff reports no changes for every host (kilimanjaro, manyara, tarangire, serengeti, arusha, katavi, mikumi, work)
- [ ] `flake check` passes