### PR TITLE
feat(infra): cloudflare DNS and worker for matrix homeserver

### DIFF
--- a/infra/global/domains/natsukium-com/main.tf
+++ b/infra/global/domains/natsukium-com/main.tf
@@ -26,6 +26,8 @@ provider "cloudflare" {
 }
 
 locals {
+  cloudflare_account_id = "dd87ce894022aec81eacd8ff1948438e"
+  zone_id               = "d318cc678ba046e46f9a7bc69f735764"
   records = {
     dotfiles = {
       content = "natsukium.github.io"
@@ -42,6 +44,14 @@ locals {
     forgejo = {
       content = "acfc103f-c6b4-4cef-8269-e1985b80e1ac.cfargotunnel.com"
       name    = "git.natsukium.com"
+      proxied = true
+      type    = "CNAME"
+    }
+    matrix = {
+      # cloudflared origin for the homeserver itself; clients and federation
+      # are pointed here by the apex Worker below, not directly via DNS.
+      content = "acfc103f-c6b4-4cef-8269-e1985b80e1ac.cfargotunnel.com"
+      name    = "matrix.natsukium.com"
       proxied = true
       type    = "CNAME"
     }
@@ -73,5 +83,20 @@ resource "cloudflare_dns_record" "record" {
   proxied  = each.value.proxied
   ttl      = 1
   type     = each.value.type
-  zone_id  = "d318cc678ba046e46f9a7bc69f735764"
+  zone_id  = local.zone_id
+}
+
+# apex delegation for Matrix discovery.
+# server_name = natsukium.com lets us use @user:natsukium.com mxids.
+resource "cloudflare_workers_script" "matrix_well_known" {
+  account_id  = local.cloudflare_account_id
+  script_name = "matrix-well-known"
+  content     = file("${path.module}/matrix-well-known.js")
+  main_module = "matrix-well-known.js"
+}
+
+resource "cloudflare_workers_route" "matrix_well_known" {
+  zone_id = local.zone_id
+  pattern = "natsukium.com/.well-known/matrix/*"
+  script  = cloudflare_workers_script.matrix_well_known.script_name
 }

--- a/infra/global/domains/natsukium-com/matrix-well-known.js
+++ b/infra/global/domains/natsukium-com/matrix-well-known.js
@@ -1,0 +1,23 @@
+const HEADERS = {
+	"content-type": "application/json",
+	"access-control-allow-origin": "*",
+	"cache-control": "public, max-age=3600",
+};
+
+const SERVER = JSON.stringify({ "m.server": "matrix.natsukium.com:443" });
+const CLIENT = JSON.stringify({
+	"m.homeserver": { base_url: "https://matrix.natsukium.com" },
+});
+
+export default {
+	async fetch(request) {
+		const { pathname } = new URL(request.url);
+		if (pathname === "/.well-known/matrix/server") {
+			return new Response(SERVER, { headers: HEADERS });
+		}
+		if (pathname === "/.well-known/matrix/client") {
+			return new Response(CLIENT, { headers: HEADERS });
+		}
+		return new Response("Not Found", { status: 404 });
+	},
+};


### PR DESCRIPTION
Adds the apex .well-known delegation Worker and the matrix.natsukium.com DNS record for the Continuwuity homeserver running on manyara.

The Worker intercepts only natsukium.com/.well-known/matrix/* and returns static JSON delegating discovery to matrix.natsukium.com:443; everything else on the apex falls through to the existing Astro blog on Pages.