### PR TITLE
refactor(infra): allow services/* prefix in tfstate IAM policies

### DIFF
--- a/infra/global/oidc/main.tf
+++ b/infra/global/oidc/main.tf
@@ -80,13 +80,19 @@ data "aws_iam_policy_document" "tfstate_read" {
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
-      values   = ["global/*"]
+      values = [
+        "global/*",
+        "services/*",
+      ]
     }
   }
 
   statement {
-    actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::natsukium-tfstate/global/*"]
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::natsukium-tfstate/global/*",
+      "arn:aws:s3:::natsukium-tfstate/services/*",
+    ]
   }
 }
 
@@ -140,7 +146,10 @@ data "aws_iam_policy_document" "tfstate_write" {
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
-      values   = ["global/*"]
+      values = [
+        "global/*",
+        "services/*",
+      ]
     }
   }
 
@@ -150,7 +159,10 @@ data "aws_iam_policy_document" "tfstate_write" {
       "s3:PutObject",
       "s3:DeleteObject",
     ]
-    resources = ["arn:aws:s3:::natsukium-tfstate/global/*"]
+    resources = [
+      "arn:aws:s3:::natsukium-tfstate/global/*",
+      "arn:aws:s3:::natsukium-tfstate/services/*",
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary

- Extend the `tfstate_read` / `tfstate_write` IAM policies in `infra/global/oidc/` to additively permit `s3:prefix=services/*` and the matching object ARNs.
- Existing `global/*` permissions are kept so current state keys (github / hydra / state / oidc / domains) continue to work unchanged.
- This is the **prerequisite** for the follow-up PR that moves the OCI / nix-builder stack to its own remote state under `services/nix-builder/terraform.tfstate`.

## Why

Stacks under `infra/services/` currently use state keys prefixed with `global/services/` even though the directory is not under `infra/global/`. The `global/` was being prepended only because the IAM allowlist required it, which tied the state-key naming convention to an IAM artifact rather than to the repo layout. Going forward the convention will be "state key mirrors the path under `infra/`", and this PR loosens IAM so that is achievable without breaking anything that already exists.

## Apply

Not on the CI matrix; apply manually after merge:

\`\`\`sh
cd infra/global/oidc
nix develop -c terraform plan
nix develop -c terraform apply
\`\`\`

## Test plan

- [ ] `terraform fmt -check` passes locally
- [ ] `terraform plan` in `infra/global/oidc/` shows only the policy document additions (no role/attachment churn)
- [ ] After apply, the new policy JSON includes both `global/*` and `services/*` in `s3:prefix` and Resource ARNs
- [ ] Existing CI workflow (`terraform.yml` for github + cloudflare matrices) continues to assume the plan/apply roles and reach state under `global/*`