### PR TITLE
ci(terraform): scope working-directory per step to handle empty matrix

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,9 +63,6 @@ jobs:
         directory: ${{ fromJson(needs.detect.outputs.directories) }}
     env:
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
-    defaults:
-      run:
-        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
@@ -76,11 +73,14 @@ jobs:
           role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}
           aws-region: us-east-2
       - name: Terraform Init
+        working-directory: ${{ matrix.directory }}
         run: nix develop -c terraform init
       - name: Terraform Format
+        working-directory: ${{ matrix.directory }}
         run: nix develop -c terraform fmt -check
       - name: Terraform Plan
         id: plan
+        working-directory: ${{ matrix.directory }}
         run: |
           set +e
           nix develop -c terraform plan -no-color -lock=false -out=tfplan > plan.txt 2>&1
@@ -120,4 +120,5 @@ jobs:
           aws-region: us-east-2
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        working-directory: ${{ matrix.directory }}
         run: nix develop -c terraform apply tfplan


### PR DESCRIPTION
## Summary

- Drop the job-level `defaults.run.working-directory: ${{ matrix.directory }}` from `.github/workflows/terraform.yml`.
- Attach `working-directory: ${{ matrix.directory }}` to each individual `run` step that needs it (Init / Format / Plan / Apply).

## Why

The `terraform` job uses a matrix derived from a path-filter detect step. When a PR touches `infra/**` but does not match any concrete filter (e.g., a change scoped to `infra/global/oidc/**`), the detect step emits `directories: '[]'`. The job-level `if: needs.detect.outputs.directories != '[]'` is supposed to skip the job in that case.

In practice it doesn't help: GitHub Actions evaluates `${{ matrix.directory }}` inside `defaults.run.working-directory` before applying the job-level `if` guard. With an empty matrix that expression resolves to `''`, which fails template validation:

\`\`\`
The template is not valid. .github/workflows/terraform.yml (Line: 68, Col: 28): Unexpected value ''
\`\`\`

Moving `working-directory` onto each step keeps the matrix expression scoped to step-level templates, which are only evaluated for matrix values that actually exist. With no matrix values, no steps are generated and the `if:` guard finally takes effect as intended.

Surfaced by #693, which is the first PR to touch a path outside the existing `services/github` and `domains/natsukium-com` filters.

## Test plan

- [ ] `actionlint` passes (verified via pre-commit hook)
- [ ] Re-run CI on #693 after this merges: the `terraform` job should now skip cleanly when the matrix is empty
- [ ] Future PRs that touch `infra/services/github/**` or `infra/global/domains/natsukium-com/**` still run plan + comment + apply in the correct directory