### PR TITLE
ci(terraform): emit valid empty JSON array when no filters match

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,7 +50,7 @@ jobs:
             if [[ "${{ steps.filter.outputs.cloudflare }}" == "true" ]]; then
               dirs+=("infra/global/domains/natsukium-com")
             fi
-            directories=$(printf '%s\n' "${dirs[@]}" | jq -R . | jq -sc .)
+            directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi
           echo "directories=$directories" >> "$GITHUB_OUTPUT"
   terraform:


### PR DESCRIPTION
## Summary

- In the detect job's `build-matrix` step, replace `printf '%s\n' "${dirs[@]}" | jq -R . | jq -sc .` with `jq -nc --args '$ARGS.positional' -- "${dirs[@]}"`.
- For an empty bash array this now correctly outputs `[]`; for a non-empty array it outputs `["a","b"]` as before.

## Why

`printf '%s\n' "${arr[@]}"` with an empty array does **not** emit zero lines. Bash drops the empty `"${arr[@]}"` expansion, so `printf` is called with the format string but no positional arguments — and `printf` reuses the format once with empty defaults, emitting a single `\n`.

The downstream `jq -R .` reads that newline as a one-element stream containing an empty string, and `jq -sc .` slurps it into `[""]`. The detect output therefore became `directories: '[""]'` whenever no filter matched, instead of the intended `'[]'`.

Consequences when a PR touched `infra/**` without matching any filter (e.g. #693, scoped to `infra/global/oidc/**`):

- The job-level `if: needs.detect.outputs.directories != '[]'` did **not** skip the terraform job.
- The matrix expanded to a single instance with `matrix.directory = ""`.
- `terraform init` ran in the repo root ("Terraform initialized in an empty directory!").
- PR comments showed an empty Plan with the literal title `Terraform Plan: \`\``.

`jq -nc --args '$ARGS.positional'` builds the JSON array directly from positional arguments, which is well-defined for zero or more elements and avoids the bash-array-to-newline-stream gymnastics. Verified locally:

\`\`\`
empty: []
1:     ["infra/services/github"]
2:     ["infra/services/github","infra/global/domains/natsukium-com"]
\`\`\`

This is the same class of bug as the earlier job-level `working-directory` issue (commit 46d7dd1242b): both surfaced because every infra/** PR before #693 happened to match a filter, so the empty-matrix branch was never exercised.

## Test plan

- [ ] `actionlint` passes (pre-commit)
- [ ] After merge, rebase #693 and verify the `terraform` job now skips cleanly (no spurious step execution, no empty plan PR comment)
- [ ] Future PRs that touch `infra/services/github/**` or `infra/global/domains/natsukium-com/**` still produce the expected matrix