### PR TITLE
refactor(infra): move OCI/nix-builder state to S3 backend

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -7,6 +7,14 @@ terraform {
       source = "carlpett/sops"
     }
   }
+
+  backend "s3" {
+    bucket       = "natsukium-tfstate"
+    encrypt      = true
+    key          = "services/nix-builder/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
 }
 
 data "sops_file" "oci-secret" {


### PR DESCRIPTION
## Summary

- Add `backend "s3"` to `infra/main.tf` (the top-level OCI/nix-builder stack) with key `services/nix-builder/terraform.tfstate`.
- No resource definitions change; this is a pure state-location migration.

## Why

The OCI stack was the only Terraform configuration in this repo still using local state. Every other stack lives in its own subdirectory with an s3 backend, encrypted + versioned + lockfile-based locking. Local state for OCI meant:

- The stack couldn't be planned/applied from another machine without manually carrying `terraform.tfstate` around.
- The state file was gitignored (`*.tfstate*`) and not versioned anywhere.
- It was inconsistent with the rest of `infra/` and an obstacle to the follow-up directory split.

The state key intentionally mirrors the eventual directory layout (`infra/services/nix-builder/`) — a separate PR will move the files there without further state migration, since changing `key` and `path` are independent operations in Terraform.

This is the first stack to adopt the "state key = path under `infra/`" convention. The earlier `global/services/*` prefix used by the github/hydra stacks is now legacy; #693 extended the OIDC IAM policy to additively permit `services/*` so this key works in CI.

## Apply (local, one-time state migration)

\`\`\`sh
cd infra
nix develop -c terraform init -migrate-state
# Prompted: "Do you want to copy existing state to the new backend?"
# → yes
nix develop -c terraform plan   # expect: No changes.
\`\`\`

## Test plan

- [ ] Local `terraform init -migrate-state` succeeds and uploads state to `s3://natsukium-tfstate/services/nix-builder/terraform.tfstate`
- [ ] `terraform plan` after migration shows no drift ("No changes. Your infrastructure matches the configuration.")
- [ ] CI workflow on this PR: the `terraform` job is skipped (no path filter matches `infra/main.tf` directly), confirming that #694 + #695 handle the empty-matrix case cleanly