### PR TITLE
feat(infra): bootstrap CI for AWS-primary stacks

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,14 +34,23 @@ jobs:
               - 'infra/services/github/**'
             cloudflare:
               - 'infra/global/domains/natsukium-com/**'
+            state:
+              - 'infra/global/state/**'
+            oidc:
+              - 'infra/global/oidc/**'
             shared:
               - 'flake.lock'
               - '.github/workflows/terraform.yml'
       - id: build-matrix
         run: |
-          directories='[]'
+          all_dirs=(
+            "infra/services/github"
+            "infra/global/domains/natsukium-com"
+            "infra/global/state"
+            "infra/global/oidc"
+          )
           if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
-            directories='["infra/services/github","infra/global/domains/natsukium-com"]'
+            directories=$(jq -nc --args '$ARGS.positional' -- "${all_dirs[@]}")
           else
             dirs=()
             if [[ "${{ steps.filter.outputs.github }}" == "true" ]]; then
@@ -49,6 +58,12 @@ jobs:
             fi
             if [[ "${{ steps.filter.outputs.cloudflare }}" == "true" ]]; then
               dirs+=("infra/global/domains/natsukium-com")
+            fi
+            if [[ "${{ steps.filter.outputs.state }}" == "true" ]]; then
+              dirs+=("infra/global/state")
+            fi
+            if [[ "${{ steps.filter.outputs.oidc }}" == "true" ]]; then
+              dirs+=("infra/global/oidc")
             fi
             directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi

--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -41,6 +41,7 @@ data "aws_iam_policy_document" "tfstate_write" {
       values = [
         "global/*",
         "services/*",
+        "aws/*",
       ]
     }
   }
@@ -54,6 +55,7 @@ data "aws_iam_policy_document" "tfstate_write" {
     resources = [
       "arn:aws:s3:::natsukium-tfstate/global/*",
       "arn:aws:s3:::natsukium-tfstate/services/*",
+      "arn:aws:s3:::natsukium-tfstate/aws/*",
     ]
   }
 }
@@ -66,4 +68,44 @@ resource "aws_iam_policy" "tfstate_write" {
 resource "aws_iam_role_policy_attachment" "apply_tfstate" {
   role       = aws_iam_role.apply.name
   policy_arn = aws_iam_policy.tfstate_write.arn
+}
+
+# Lets apply_role self-update the OIDC stack via CI. ARN patterns bound
+# the blast radius — IAM resources outside this stack's naming conventions
+# are unreachable. Self-trust edits remain possible; PR review and console
+# recovery are the mitigations.
+data "aws_iam_policy_document" "apply_iam_oidc" {
+  statement {
+    actions = [
+      "iam:Get*",
+      "iam:List*",
+      "iam:Create*",
+      "iam:Delete*",
+      "iam:Update*",
+      "iam:Put*",
+      "iam:Tag*",
+      "iam:Untag*",
+      "iam:Attach*",
+      "iam:Detach*",
+      "iam:AddClient*",
+      "iam:RemoveClient*",
+      "iam:SetDefault*",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/github-actions-*",
+      "arn:aws:iam::*:policy/tfstate-*",
+      "arn:aws:iam::*:policy/apply-*",
+      "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "apply_iam_oidc" {
+  name   = "apply-iam-oidc-stack"
+  policy = data.aws_iam_policy_document.apply_iam_oidc.json
+}
+
+resource "aws_iam_role_policy_attachment" "apply_iam_oidc" {
+  role       = aws_iam_role.apply.name
+  policy_arn = aws_iam_policy.apply_iam_oidc.arn
 }

--- a/infra/global/oidc/iam-plan.tf
+++ b/infra/global/oidc/iam-plan.tf
@@ -45,6 +45,7 @@ data "aws_iam_policy_document" "tfstate_read" {
       values = [
         "global/*",
         "services/*",
+        "aws/*",
       ]
     }
   }
@@ -54,6 +55,7 @@ data "aws_iam_policy_document" "tfstate_read" {
     resources = [
       "arn:aws:s3:::natsukium-tfstate/global/*",
       "arn:aws:s3:::natsukium-tfstate/services/*",
+      "arn:aws:s3:::natsukium-tfstate/aws/*",
     ]
   }
 }
@@ -66,4 +68,11 @@ resource "aws_iam_policy" "tfstate_read" {
 resource "aws_iam_role_policy_attachment" "plan_tfstate" {
   role       = aws_iam_role.plan.name
   policy_arn = aws_iam_policy.tfstate_read.arn
+}
+
+# Broad ReadOnlyAccess (vs per-service read) chosen because read access is
+# low-risk and terraform refresh needs Get/List across many services.
+resource "aws_iam_role_policy_attachment" "plan_readonly" {
+  role       = aws_iam_role.plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }


### PR DESCRIPTION
## Summary
Enables CI plan/apply for foundation stacks where AWS is the primary provider, plus the upcoming \`infra/aws/\` tree:

- Workflow: path-filters for \`state\` and \`oidc\` so changes there route through plan/apply like existing stacks
- Open the \`aws/*\` tfstate bucket prefix to plan_role and apply_role
- Attach \`ReadOnlyAccess\` to plan_role so terraform refresh works on AWS-primary stacks
- Add \`apply-iam-oidc-stack\` custom policy with name-scoped IAM permissions so apply_role can self-update this OIDC stack via CI

The self-management policy is preferred over \`IAMFullAccess\`; ARN patterns (\`github-actions-*\`, \`tfstate-*\`, \`apply-*\`, the GitHub OIDC provider) bound the blast radius if the OIDC token leaks.

## Bootstrap
One manual apply after merge so apply_role gains the new permissions:

\`\`\`fish
aws-vault exec <personal-admin> -- terraform -chdir=infra/global/oidc apply
\`\`\`

After that, subsequent OIDC stack changes flow through CI.

## Test plan
- [ ] Local \`terraform plan\` diff shows expected additions (S3 prefix expansion, ReadOnlyAccess + apply-iam-oidc-stack attachments)
- [ ] Local \`terraform apply\` succeeds
- [ ] IAM console shows the new policy attachments on \`github-actions-terraform-apply\` and \`github-actions-terraform-plan\`

## Follow-ups
- #700-ish: AWS Organizations management permission (\`AWSOrganizationsFullAccess\` + SLR)
- Then: the \`infra/aws/organization\` stack itself