### PR TITLE
feat(infra/oidc): grant apply_role AWS Organizations management

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -70,6 +70,36 @@ resource "aws_iam_role_policy_attachment" "apply_tfstate" {
   policy_arn = aws_iam_policy.tfstate_write.arn
 }
 
+# Per-stack managed policies (vs AdministratorAccess) to bound blast radius
+# if the OIDC token leaks. New stacks add their own policies here.
+resource "aws_iam_role_policy_attachment" "apply_organizations" {
+  role       = aws_iam_role.apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSOrganizationsFullAccess"
+}
+
+# AWSOrganizationsFullAccess covers iam:CreateServiceLinkedRole only for
+# organizations itself; sso/cloudtrail/guardduty SLRs need this extra grant.
+data "aws_iam_policy_document" "apply_iam_slr" {
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:DeleteServiceLinkedRole",
+      "iam:GetServiceLinkedRoleDeletionStatus",
+    ]
+    resources = ["arn:aws:iam::*:role/aws-service-role/*"]
+  }
+}
+
+resource "aws_iam_policy" "apply_iam_slr" {
+  name   = "apply-iam-service-linked-role"
+  policy = data.aws_iam_policy_document.apply_iam_slr.json
+}
+
+resource "aws_iam_role_policy_attachment" "apply_iam_slr" {
+  role       = aws_iam_role.apply.name
+  policy_arn = aws_iam_policy.apply_iam_slr.arn
+}
+
 # Lets apply_role self-update the OIDC stack via CI. ARN patterns bound
 # the blast radius — IAM resources outside this stack's naming conventions
 # are unreachable. Self-trust edits remain possible; PR review and console


### PR DESCRIPTION
## Summary
Adds the permissions \`apply_role\` needs to manage the upcoming \`infra/aws/organization\` stack:

- \`AWSOrganizationsFullAccess\` for creating and managing the org, OUs, and member accounts
- \`apply-iam-service-linked-role\` custom policy scoped to \`aws-service-role/*\` ARNs (\`AWSOrganizationsFullAccess\` only grants SLR creation for \`organizations.amazonaws.com\` itself; enabling additional service principals — sso, cloudtrail, guardduty — requires SLR creation for each)

## Dependencies
Stacked on #699. Merge that first; once its bootstrap apply has run, \`apply_role\` has \`apply-iam-oidc-stack\` and can self-modify this OIDC stack via CI — so this PR flows through CI without further manual intervention.

## Test plan
- [ ] CI plan diff shows two policy additions on \`github-actions-terraform-apply\` (managed \`AWSOrganizationsFullAccess\`, custom \`apply-iam-service-linked-role\`)
- [ ] After merge, CI apply completes successfully