### PR TITLE
feat(infra/aws): add Organizations and research member account

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -38,6 +38,8 @@ jobs:
               - 'infra/global/state/**'
             oidc:
               - 'infra/global/oidc/**'
+            aws_organization:
+              - 'infra/aws/organization/**'
             shared:
               - 'flake.lock'
               - '.github/workflows/terraform.yml'
@@ -48,6 +50,7 @@ jobs:
             "infra/global/domains/natsukium-com"
             "infra/global/state"
             "infra/global/oidc"
+            "infra/aws/organization"
           )
           if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
             directories=$(jq -nc --args '$ARGS.positional' -- "${all_dirs[@]}")
@@ -64,6 +67,9 @@ jobs:
             fi
             if [[ "${{ steps.filter.outputs.oidc }}" == "true" ]]; then
               dirs+=("infra/global/oidc")
+            fi
+            if [[ "${{ steps.filter.outputs.aws_organization }}" == "true" ]]; then
+              dirs+=("infra/aws/organization")
             fi
             directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi

--- a/infra/aws/organization/main.tf
+++ b/infra/aws/organization/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    sops = {
+      source = "carlpett/sops"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "natsukium-tfstate"
+    encrypt      = true
+    key          = "aws/organization/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+data "sops_file" "secrets" {
+  source_file = "secrets.yaml"
+}
+
+# feature_set "ALL" (not "CONSOLIDATED_BILLING") so SCPs and Identity Center
+# can be attached in later stacks.
+resource "aws_organizations_organization" "main" {
+  feature_set = "ALL"
+
+  aws_service_access_principals = [
+    "sso.amazonaws.com",
+    "cloudtrail.amazonaws.com",
+    "guardduty.amazonaws.com",
+    "account.amazonaws.com",
+  ]
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY",
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Workloads OU isolates SCP targets from the management account; attaching
+# guardrails to the org root risks self-lockout.
+resource "aws_organizations_organizational_unit" "workloads" {
+  name      = "Workloads"
+  parent_id = aws_organizations_organization.main.roots[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# close_on_deletion = false: closure is a 90-day irreversible operation
+# that should be triggered deliberately via the console, not by terraform.
+resource "aws_organizations_account" "research" {
+  name              = "research"
+  email             = data.sops_file.secrets.data["research_root_email"]
+  parent_id         = aws_organizations_organizational_unit.workloads.id
+  close_on_deletion = false
+
+  tags = {
+    Purpose = "research"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "organization_id" {
+  value = aws_organizations_organization.main.id
+}
+
+output "workloads_ou_id" {
+  value = aws_organizations_organizational_unit.workloads.id
+}
+
+output "research_account_id" {
+  value = aws_organizations_account.research.id
+}

--- a/infra/aws/organization/secrets.yaml
+++ b/infra/aws/organization/secrets.yaml
@@ -1,0 +1,28 @@
+research_root_email: ENC[AES256_GCM,data:I+1AQP788mthqGkUB2RMAYHDE3LMJB+pmP/HSm+/Xg==,iv:F2vhGjjOJj0YTO81YB1bsUQ1tG9CkKmxU/zFi4jZBOI=,tag:KEbQP87YYtU2OabTw7Hfzg==,type:str]
+sops:
+  age:
+    - recipient: age1pk0z5nauz3extrv3kqqksl6yf433nk66jq9s3kk6xz07nnwxcddq9z7vhc
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYm05TVFqeWlqeEQrVjNx
+        ZFAvQWVkVEJLdllnemhhbU5UdmVPMW9MMDA4Cjd5ZDlZMW5CbEdVY0g3d0lQektU
+        Tm55MVpXMHBLVDZpMDhsZHk1RGJDRjQKLS0tIFBaRjNJRmtBWWVMMVlNdkhiazUw
+        UFVBMXhGRkxyMm9MV2JwUTFxaDI1dDAKn5a7Uv7+vnKq+tPQ/IM8ACDZ2cnxmyTU
+        6RAfrN932kWJTeAM/K6n6nbxlCwNTzgZ7/3Y0+WeLX0LkkjY8FLknA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-15T15:30:17Z"
+  mac: ENC[AES256_GCM,data:/vqtTyX6Tbgr/ylyIdjfuceCoaPQ1jp3QjBSmrXm+3NqSnHMLBpEwM1T7IzD5G62/u7xnrzA6LbFHw/sH1DvQpw0QS6NnYwE5At3gGZ9f8tY4NpQ7FErvmVyzyFqk6HLUpLFgJQC12rizsSblKUFJtqegCj9+XLoQGrWkVRboCw=,iv:RhQel3ooWSL6KsBW0XSR9u9D+q9bGqkrkX9iOukcBhE=,tag:spdCBHL4lpKfmd8806C6bg==,type:str]
+  pgp:
+    - created_at: "2026-05-15T15:30:17Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4DA2FdwJLszpkSAQdA0Wv85xE77WqCLr27Adu+iwd/nqU79czIxHZgHy1/ggAw
+        AlzbzaamFQBVfqp+Z+v38kqzgs/X5rolGXtLwxhDpF7rsMCjIEsOmxymFUzqOKy1
+        0l4BlE4Gvls8oqHdda/ttPOfYfb5nJaEasBuPNxl8RtC7mAZXQuEWDABUS57hBH2
+        fmI5GFhyLRMDaVvOV/zG6IYX6K8C3b/WLqYzteKbQFj+81Z0oZ0vLjVbBKduIgEm
+        =z5BX
+        -----END PGP MESSAGE-----
+      fp: 20D22783FF50D18568CF617303615DC092ECCE99
+  unencrypted_suffix: _unencrypted
+  version: 3.12.2


### PR DESCRIPTION
## Summary
New stack at \`infra/aws/organization\` creates the AWS Organization (\`feature_set = "ALL"\`), a \`Workloads\` OU isolating SCP targets from the management account, and a \`research\` member account intended for family-shared use. The root account email is sops-encrypted in \`secrets.yaml\` since this repo is public. \`prevent_destroy\` on all three resources blocks accidental destroy via terraform.

Workflow filter is expanded to detect changes under the new directory so it routes through plan/apply like existing stacks.

## Dependencies
#699 (bootstrap CI) and #701 (Org management perms) are already merged. apply_role has \`AWSOrganizationsFullAccess\` + SLR perms, so CI here can plan/apply this stack without further manual intervention.

Recreated from closed #700 (auto-closed when its base branch was deleted on merge of #701).

## Test plan
- [ ] CI plan shows expected creates: \`aws_organizations_organization.main\`, \`aws_organizations_organizational_unit.workloads\`, \`aws_organizations_account.research\`
- [ ] After merge, CI apply completes and the \`research_account_id\` output is populated
- [ ] AWS sends verification email to \`tomoya.otabi+research@gmail.com\`
- [ ] Manual follow-up: set up MFA, password, contact info on research root via console