### PR TITLE
feat(infra/oidc): grant apply_role IAM Identity Center management

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -100,6 +100,20 @@ resource "aws_iam_role_policy_attachment" "apply_iam_slr" {
   policy_arn = aws_iam_policy.apply_iam_slr.arn
 }
 
+# Identity Center management splits across two AWS-managed policies: the
+# master account scope (permission sets, account assignments) and the
+# identity store scope (users, groups, memberships). Both are needed for
+# the infra/aws/identity-center stack to apply end-to-end.
+resource "aws_iam_role_policy_attachment" "apply_sso_master" {
+  role       = aws_iam_role.apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSSOMasterAccountAdministrator"
+}
+
+resource "aws_iam_role_policy_attachment" "apply_sso_directory" {
+  role       = aws_iam_role.apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryAdministrator"
+}
+
 # Lets apply_role self-update the OIDC stack via CI. ARN patterns bound
 # the blast radius — IAM resources outside this stack's naming conventions
 # are unreachable. Self-trust edits remain possible; PR review and console


### PR DESCRIPTION
## Summary
Adds the permissions \`apply_role\` needs to manage the upcoming \`infra/aws/identity-center\` stack:

- \`AWSSSOMasterAccountAdministrator\` — permission sets and account assignments at the management account scope
- \`AWSSSODirectoryAdministrator\` — Identity Center directory (users, groups, group memberships)

IdC splits its management surface across these two policies. SLR creation for \`sso.amazonaws.com\` is already covered by the existing \`apply-iam-service-linked-role\` policy.

## Dependencies
Independent. Will be applied via CI through the existing \`apply-iam-oidc-stack\` self-management path established in #699.

Follow-up PR will create the actual IdC stack.

## Test plan
- [ ] CI plan shows the two managed policy attachments on \`github-actions-terraform-apply\`
- [ ] After merge, CI apply completes successfully