### PR TITLE
feat(infra/aws): add Identity Center stack with admins and members

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,6 +40,8 @@ jobs:
               - 'infra/global/oidc/**'
             aws_organization:
               - 'infra/aws/organization/**'
+            aws_identity_center:
+              - 'infra/aws/identity-center/**'
             shared:
               - 'flake.lock'
               - '.github/workflows/terraform.yml'
@@ -51,6 +53,7 @@ jobs:
             "infra/global/state"
             "infra/global/oidc"
             "infra/aws/organization"
+            "infra/aws/identity-center"
           )
           if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
             directories=$(jq -nc --args '$ARGS.positional' -- "${all_dirs[@]}")
@@ -70,6 +73,9 @@ jobs:
             fi
             if [[ "${{ steps.filter.outputs.aws_organization }}" == "true" ]]; then
               dirs+=("infra/aws/organization")
+            fi
+            if [[ "${{ steps.filter.outputs.aws_identity_center }}" == "true" ]]; then
+              dirs+=("infra/aws/identity-center")
             fi
             directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi

--- a/infra/aws/identity-center/main.tf
+++ b/infra/aws/identity-center/main.tf
@@ -1,0 +1,180 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    sops = {
+      source = "carlpett/sops"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "natsukium-tfstate"
+    encrypt      = true
+    key          = "aws/identity-center/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
+}
+
+# IdC is regional and its region was fixed at console enablement to
+# ap-northeast-1. The provider region must match for the SSO and
+# identitystore APIs to find the instance.
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+data "sops_file" "secrets" {
+  source_file = "secrets.yaml"
+}
+
+# Identity Center has no Terraform resource for instance creation; the
+# instance is enabled manually in the management account console. This
+# data source picks it up.
+data "aws_ssoadmin_instances" "main" {}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "organization" {
+  backend = "s3"
+  config = {
+    bucket = "natsukium-tfstate"
+    key    = "aws/organization/terraform.tfstate"
+    region = "us-east-2"
+  }
+}
+
+locals {
+  instance_arn      = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+}
+
+# === Users ===
+resource "aws_identitystore_user" "tomoya" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "Tomoya Otabi"
+  user_name    = "tomoya"
+
+  name {
+    given_name  = "Tomoya"
+    family_name = "Otabi"
+  }
+
+  emails {
+    value   = data.sops_file.secrets.data["tomoya_email"]
+    primary = true
+  }
+}
+
+resource "aws_identitystore_user" "hikari" {
+  identity_store_id = local.identity_store_id
+
+  display_name = "Hikari Otabi"
+  user_name    = "hikari"
+
+  name {
+    given_name  = "Hikari"
+    family_name = "Otabi"
+  }
+
+  emails {
+    value   = data.sops_file.secrets.data["hikari_email"]
+    primary = true
+  }
+}
+
+# === Groups ===
+resource "aws_identitystore_group" "admins" {
+  identity_store_id = local.identity_store_id
+  display_name      = "admins"
+  description       = "Account administrators across all member accounts."
+}
+
+resource "aws_identitystore_group" "members" {
+  identity_store_id = local.identity_store_id
+  display_name      = "members"
+  description       = "Non-admin members of the organization."
+}
+
+resource "aws_identitystore_group_membership" "tomoya_admins" {
+  identity_store_id = local.identity_store_id
+  group_id          = aws_identitystore_group.admins.group_id
+  member_id         = aws_identitystore_user.tomoya.user_id
+}
+
+resource "aws_identitystore_group_membership" "hikari_members" {
+  identity_store_id = local.identity_store_id
+  group_id          = aws_identitystore_group.members.group_id
+  member_id         = aws_identitystore_user.hikari.user_id
+}
+
+# === Permission Sets ===
+resource "aws_ssoadmin_permission_set" "administrator_access" {
+  instance_arn     = local.instance_arn
+  name             = "AdministratorAccess"
+  session_duration = "PT8H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "administrator_access" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+# PowerUserAccess grants full access except IAM and Organizations
+# management, preventing members from elevating their own privileges or
+# modifying org-level resources.
+resource "aws_ssoadmin_permission_set" "power_user_access" {
+  instance_arn     = local.instance_arn
+  name             = "PowerUserAccess"
+  session_duration = "PT8H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "power_user_access" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.power_user_access.arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+# === Account assignments ===
+resource "aws_ssoadmin_account_assignment" "admins_management" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+
+  principal_type = "GROUP"
+  principal_id   = aws_identitystore_group.admins.group_id
+
+  target_type = "AWS_ACCOUNT"
+  target_id   = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_ssoadmin_account_assignment" "admins_research" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn
+
+  principal_type = "GROUP"
+  principal_id   = aws_identitystore_group.admins.group_id
+
+  target_type = "AWS_ACCOUNT"
+  target_id   = data.terraform_remote_state.organization.outputs.research_account_id
+}
+
+resource "aws_ssoadmin_account_assignment" "members_research" {
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.power_user_access.arn
+
+  principal_type = "GROUP"
+  principal_id   = aws_identitystore_group.members.group_id
+
+  target_type = "AWS_ACCOUNT"
+  target_id   = data.terraform_remote_state.organization.outputs.research_account_id
+}
+
+output "sso_instance_arn" {
+  value = local.instance_arn
+}
+
+output "identity_store_id" {
+  value = local.identity_store_id
+}

--- a/infra/aws/identity-center/secrets.yaml
+++ b/infra/aws/identity-center/secrets.yaml
@@ -1,0 +1,29 @@
+tomoya_email: ENC[AES256_GCM,data:zreFV3aaNN7HuM4DQ3qZRPkaQT4ZGg==,iv:3/LqWvt88t8ty8s7kLQXUOoOjTu+6uHT4R5GOdlAyew=,tag:QCtXgIL7BSzNwVfsOROq3Q==,type:str]
+hikari_email: ENC[AES256_GCM,data:Sy2H7k0R0I/lKHnR8nwK1ve79S1DAw==,iv:+WXURZOYvqnQ450F/7cdGzuqaUU23z9buhGp1CA98OI=,tag:g87cUDdFXtsekfsfJawosA==,type:str]
+sops:
+  age:
+    - recipient: age1pk0z5nauz3extrv3kqqksl6yf433nk66jq9s3kk6xz07nnwxcddq9z7vhc
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTVHZYaEZ5STdGcVBQanEz
+        Q3JidTdWM2wrK1VGcnF1Qm44QU9uY0QwVWpnClRLa296S0tMNDNmTndXTU9Zb21i
+        WFZScWJCaFFiOFJ1K0JOZ3ZleHJxVWsKLS0tIG1vOXJRTWVES2pZTjBNTjgxa3Vm
+        N2hOYkZTV1dtN0Z4dnN3a1htWGtPRGcKvRBltax0sPUjwUFw9GcO887SZ6AB0koi
+        fvIoxuGQxSo9d6p3wXLVIEZHFKBN3BQ+CZPbvzgxFOs/7zz+NFPDtg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-16T06:10:17Z"
+  mac: ENC[AES256_GCM,data:Ul0z2XWHdnqgrWImxieA7GC7UrwipoGsK8bGZ8UO7nvk6iVC6+Kcev6oc6UUogGY0gBBvcHDm+izPV69hgxIvrejYKNt6ZrXBT8z1gmshfy5gt5/erKsqTCdECbHsKiZXE3QFTB6jl0zRkVfsTV5mtPxR48CGsC2QwD2N6kWnX4=,iv:KoEeji91q919/ycyApahX2/mcw37QkhlEsznC7hs7PQ=,tag:N7IxUn7E8WjDCVxwMRswHw==,type:str]
+  pgp:
+    - created_at: "2026-05-16T06:10:17Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4DA2FdwJLszpkSAQdAXZjWJ3myb6pyV7jnFZebKtVV15hQ9WS1LjN3FvfKzA8w
+        p6nH9a79PPCTOWscuV3iv+3bIDUUSEDU2gwwmL8SUiKAzighTBqzDD4wAFrpmbIF
+        0l4BnxET85Nkf60G2VSg40FI88r+9x02L72J2Q8xgmvPPJZggOKbMe58PjjPt2YU
+        why9iPJY+XVOXBnZhdD+eBX5zyl4sNGU7zijT5Ym8T2XZeZ5AaXuSA/ufOvuYyuH
+        =g93u
+        -----END PGP MESSAGE-----
+      fp: 20D22783FF50D18568CF617303615DC092ECCE99
+  unencrypted_suffix: _unencrypted
+  version: 3.12.2


### PR DESCRIPTION
## Summary
New stack at \`infra/aws/identity-center\` provisions human access through IAM Identity Center:

- **Users**: \`tomoya\`, \`hikari\` (emails sops-encrypted)
- **Groups**: \`admins\`, \`members\`
- **Permission sets**: \`AdministratorAccess\` (8h), \`PowerUserAccess\` (8h)
- **Assignments**:
  - \`admins\` → management + research with \`AdministratorAccess\`
  - \`members\` → research with \`PowerUserAccess\` (no IAM/Org access; cannot self-elevate)

Provider region pinned to \`ap-northeast-1\` to match the IdC instance enabled manually in the management account console.

Workflow filters expanded to detect changes under the new directory.

## Manual prerequisite (already done)
IAM Identity Center must be enabled in the management account console at \`ap-northeast-1\` before this stack can resolve the instance. The AWS provider has no resource for instance creation.

## Dependencies
#703 is already merged, granting \`apply_role\` the SSO management permissions needed for this stack to apply via CI.

## Side effect on apply: invitation emails
On apply, AWS sends invitation emails to:
- \`tomoya.otabi@gmail.com\` (user: tomoya)
- \`hikari.otabi@gmail.com\` (user: hikari)

Hikari should be pre-notified that a setup link is incoming.

## Test plan
- [ ] CI plan shows expected creates: 2 users, 2 groups, 2 memberships, 2 permission sets + managed policy attachments, 3 account assignments
- [ ] After merge, CI apply completes
- [ ] Both users receive setup emails
- [ ] Both users set passwords and MFA via the IdC portal
- [ ] tomoya can sign in via SSO portal and assume \`AdministratorAccess\` on both accounts
- [ ] hikari can sign in and assume \`PowerUserAccess\` on the research account only