### PR TITLE
fix(infra/oidc): grant apply_role iam:GetSAMLProvider for IdC assignments

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -114,6 +114,28 @@ resource "aws_iam_role_policy_attachment" "apply_sso_directory" {
   policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryAdministrator"
 }
 
+# AWSSSOMasterAccountAdministrator omits iam:GetSAMLProvider on the SAML
+# provider that IdC creates and depends on (AWSSSO_*_DO_NOT_DELETE).
+# Without it, aws_ssoadmin_account_assignment fails when verifying the
+# underlying SAML trust during create. Scoped to AWSSSO_* providers to
+# avoid touching unrelated SAML configurations.
+data "aws_iam_policy_document" "apply_sso_saml" {
+  statement {
+    actions   = ["iam:GetSAMLProvider"]
+    resources = ["arn:aws:iam::*:saml-provider/AWSSSO_*"]
+  }
+}
+
+resource "aws_iam_policy" "apply_sso_saml" {
+  name   = "apply-sso-saml-provider"
+  policy = data.aws_iam_policy_document.apply_sso_saml.json
+}
+
+resource "aws_iam_role_policy_attachment" "apply_sso_saml" {
+  role       = aws_iam_role.apply.name
+  policy_arn = aws_iam_policy.apply_sso_saml.arn
+}
+
 # Lets apply_role self-update the OIDC stack via CI. ARN patterns bound
 # the blast radius — IAM resources outside this stack's naming conventions
 # are unreachable. Self-trust edits remain possible; PR review and console


### PR DESCRIPTION
## Summary
Hotfix for the CI apply failure on #704:

\`\`\`
Error: waiting for SSO Account Assignment for GROUP create: unexpected state 'FAILED'.
last error: iam:GetSAMLProvider on resource:
  arn:aws:iam::...:saml-provider/AWSSSO_cd5bfb301b6c971e_DO_NOT_DELETE
  because no identity-based policy allows the iam:GetSAMLProvider action
\`\`\`

\`AWSSSOMasterAccountAdministrator\` does not include \`iam:GetSAMLProvider\` on the SAML provider that IAM Identity Center creates and depends on for SSO authentication. Account assignment creation needs to read this provider to verify the underlying SAML trust.

Adding a small custom policy scoped to \`arn:aws:iam::*:saml-provider/AWSSSO_*\` to bound the blast radius.

## After merge
1. CI applies this change → \`apply_role\` gets the new permission
2. Re-trigger the failed identity-center apply (manual rerun or trivial commit to the dir)

## Test plan
- [ ] CI plan shows 1 new custom policy + 1 attachment to apply_role
- [ ] After merge and apply, identity-center stack apply succeeds (assignments create cleanly)