### PR TITLE
fix(infra/oidc): extend apply_role SAML provider perms for IdC assignments

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -114,14 +114,22 @@ resource "aws_iam_role_policy_attachment" "apply_sso_directory" {
   policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryAdministrator"
 }
 
-# AWSSSOMasterAccountAdministrator omits iam:GetSAMLProvider on the SAML
+# AWSSSOMasterAccountAdministrator omits SAML provider management on the
 # provider that IdC creates and depends on (AWSSSO_*_DO_NOT_DELETE).
-# Without it, aws_ssoadmin_account_assignment fails when verifying the
-# underlying SAML trust during create. Scoped to AWSSSO_* providers to
-# avoid touching unrelated SAML configurations.
+# aws_ssoadmin_account_assignment internally calls Get/Create/Update on
+# this provider during assignment lifecycle. Scoped to AWSSSO_* providers
+# to avoid touching unrelated SAML configurations.
 data "aws_iam_policy_document" "apply_sso_saml" {
   statement {
-    actions   = ["iam:GetSAMLProvider"]
+    actions = [
+      "iam:GetSAMLProvider",
+      "iam:CreateSAMLProvider",
+      "iam:UpdateSAMLProvider",
+      "iam:DeleteSAMLProvider",
+      "iam:TagSAMLProvider",
+      "iam:UntagSAMLProvider",
+      "iam:ListSAMLProviderTags",
+    ]
     resources = ["arn:aws:iam::*:saml-provider/AWSSSO_*"]
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #705. After granting \`iam:GetSAMLProvider\`, the IdC account assignment apply hit the next missing permission in the chain:

\`\`\`
iam:CreateSAMLProvider on resource: arn:aws:iam::...:saml-provider/AWSSSO_*_DO_NOT_DELETE
\`\`\`

IdC's assignment lifecycle internally calls multiple SAML provider operations (Get/Create/Update/Tag) on the AWSSSO_* provider, none of which are included in \`AWSSSOMasterAccountAdministrator\`. Granting the full SAML provider lifecycle scoped to the same ARN pattern.

## After merge
1. CI applies this → \`apply_role\` gets extended perms
2. \`gh run rerun 25954856038 --failed\` to retry the original identity-center apply

## Test plan
- [ ] CI plan shows policy version update for \`apply-sso-saml-provider\` adding 6 more actions
- [ ] After merge & apply, retrying the failed identity-center run succeeds