### PR TITLE
fix(infra/oidc): consolidate IdC IAM perms with iam:* on scoped resources

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -114,34 +114,33 @@ resource "aws_iam_role_policy_attachment" "apply_sso_directory" {
   policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryAdministrator"
 }
 
-# AWSSSOMasterAccountAdministrator omits SAML provider management on the
-# provider that IdC creates and depends on (AWSSSO_*_DO_NOT_DELETE).
-# aws_ssoadmin_account_assignment internally calls Get/Create/Update on
-# this provider during assignment lifecycle. Scoped to AWSSSO_* providers
-# to avoid touching unrelated SAML configurations.
-data "aws_iam_policy_document" "apply_sso_saml" {
+# AWSSSOMasterAccountAdministrator's actual contents have gaps not
+# reflected in AWS docs: it lacks IAM perms for the SAML provider IdC
+# depends on (AWSSSO_*_DO_NOT_DELETE) AND for the reserved permission-set
+# roles IdC creates per assignment (aws-reserved/sso.amazonaws.com/*).
+#
+# Granting iam:* on these two specific resource ARN patterns covers the
+# full IdC operation surface without enumerating individual API calls
+# (Get/Create/Update/Delete/Attach/Detach/Tag/...) — apply_role still
+# cannot touch IAM resources outside IdC's reserved naming.
+data "aws_iam_policy_document" "apply_sso_iam" {
   statement {
-    actions = [
-      "iam:GetSAMLProvider",
-      "iam:CreateSAMLProvider",
-      "iam:UpdateSAMLProvider",
-      "iam:DeleteSAMLProvider",
-      "iam:TagSAMLProvider",
-      "iam:UntagSAMLProvider",
-      "iam:ListSAMLProviderTags",
+    actions = ["iam:*"]
+    resources = [
+      "arn:aws:iam::*:saml-provider/AWSSSO_*",
+      "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*",
     ]
-    resources = ["arn:aws:iam::*:saml-provider/AWSSSO_*"]
   }
 }
 
-resource "aws_iam_policy" "apply_sso_saml" {
-  name   = "apply-sso-saml-provider"
-  policy = data.aws_iam_policy_document.apply_sso_saml.json
+resource "aws_iam_policy" "apply_sso_iam" {
+  name   = "apply-sso-iam"
+  policy = data.aws_iam_policy_document.apply_sso_iam.json
 }
 
-resource "aws_iam_role_policy_attachment" "apply_sso_saml" {
+resource "aws_iam_role_policy_attachment" "apply_sso_iam" {
   role       = aws_iam_role.apply.name
-  policy_arn = aws_iam_policy.apply_sso_saml.arn
+  policy_arn = aws_iam_policy.apply_sso_iam.arn
 }
 
 # Lets apply_role self-update the OIDC stack via CI. ARN patterns bound


### PR DESCRIPTION
## Summary
Third (and hopefully last) IAM permission fix for the IdC account assignment apply. After #705 and #706 each unlocked one more missing perm, the next missing one was:

\`\`\`
iam:CreateRole on arn:aws:iam::...:role/aws-reserved/sso.amazonaws.com/ap-northeast-1/AWSReservedSSO_AdministratorAccess_*
\`\`\`

\`AWSSSOMasterAccountAdministrator\`'s documented action list does not match its actual contents. Rather than continuing whack-a-mole, this consolidates all IdC IAM needs into one policy with \`iam:*\` scoped to two resource ARN patterns:

- \`arn:aws:iam::*:saml-provider/AWSSSO_*\` — the IdC SAML provider
- \`arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*\` — the reserved permission-set roles IdC creates per assignment

The wildcard is on the action, but the resource ARN restriction keeps the blast radius tight: \`apply_role\` cannot touch any IAM resources outside these IdC-reserved naming patterns.

Replaces the policy from #706 (which only covered SAML provider, missing the role creation).

## After merge
1. CI applies this → \`apply_role\` swaps the saml-provider-only policy for the new combined one
2. \`gh run rerun 25954856038 --failed\` to retry the original identity-center apply

## Test plan
- [ ] CI plan shows: delete \`apply-sso-saml-provider\` policy + attachment, create \`apply-sso-iam\` policy + attachment
- [ ] After merge & apply, retrying the failed identity-center run succeeds end-to-end