### PR TITLE
feat(infra/oidc): grant CI roles cross-account access to research

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -182,3 +182,23 @@ resource "aws_iam_role_policy_attachment" "apply_iam_oidc" {
   role       = aws_iam_role.apply.name
   policy_arn = aws_iam_policy.apply_iam_oidc.arn
 }
+
+# Cross-account assume into research for the infra/aws/accounts/research
+# stack. OrganizationAccountAccessRole is the default admin role created
+# when AWS Organizations provisions a member account.
+data "aws_iam_policy_document" "apply_research_assume" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::907199504666:role/OrganizationAccountAccessRole"]
+  }
+}
+
+resource "aws_iam_policy" "apply_research_assume" {
+  name   = "apply-research-account-assume-role"
+  policy = data.aws_iam_policy_document.apply_research_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "apply_research_assume" {
+  role       = aws_iam_role.apply.name
+  policy_arn = aws_iam_policy.apply_research_assume.arn
+}

--- a/infra/global/oidc/iam-plan.tf
+++ b/infra/global/oidc/iam-plan.tf
@@ -76,3 +76,25 @@ resource "aws_iam_role_policy_attachment" "plan_readonly" {
   role       = aws_iam_role.plan.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
+
+# Cross-account assume into research for the infra/aws/accounts/research
+# stack. OrganizationAccountAccessRole is admin-scoped; a read-only role
+# would be tighter for plan but adds bootstrap overhead not justified at
+# this scale. Terraform plan only issues reads, so the practical capability
+# is bounded to refresh operations.
+data "aws_iam_policy_document" "plan_research_assume" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::907199504666:role/OrganizationAccountAccessRole"]
+  }
+}
+
+resource "aws_iam_policy" "plan_research_assume" {
+  name   = "plan-research-account-assume-role"
+  policy = data.aws_iam_policy_document.plan_research_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "plan_research_assume" {
+  role       = aws_iam_role.plan.name
+  policy_arn = aws_iam_policy.plan_research_assume.arn
+}


### PR DESCRIPTION
## Summary
Both \`plan_role\` and \`apply_role\` need to assume into the research member account for the upcoming \`infra/aws/accounts/research\` stack. The target is \`OrganizationAccountAccessRole\` — the admin role AWS Organizations auto-creates when provisioning a member account.

Adds:
- \`plan-research-account-assume-role\` custom policy → attached to \`plan_role\`
- \`apply-research-account-assume-role\` custom policy → attached to \`apply_role\`

## Trade-off: shared admin role for both plan and apply
Tighter separation (a dedicated read-only role for plan) was considered but rejected:
- Adds a bootstrap step (read-only role must exist before plan can use it)
- Requires workflow changes (different \`TF_VAR_assume_role_arn\` per step)
- Personal-scale threat model: plan_role assumable only from this repo's PR/main, single contributor, and \`terraform plan\` only issues read APIs

The split can be added later as the org grows.

## Dependencies
Independent. Applies via CI through the existing \`apply-iam-oidc-stack\` self-management path.

## Test plan
- [ ] CI plan shows two custom IAM policy creates and two role attachments
- [ ] After merge, CI apply completes
- [ ] \`plan_role\` and \`apply_role\` each show the new policy attached in the IAM console