### PR TITLE
feat(infra/aws): add research workload stack with experiments S3 bucket

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,6 +42,8 @@ jobs:
               - 'infra/aws/organization/**'
             aws_identity_center:
               - 'infra/aws/identity-center/**'
+            aws_accounts_research:
+              - 'infra/aws/accounts/research/**'
             shared:
               - 'flake.lock'
               - '.github/workflows/terraform.yml'
@@ -54,6 +56,7 @@ jobs:
             "infra/global/oidc"
             "infra/aws/organization"
             "infra/aws/identity-center"
+            "infra/aws/accounts/research"
           )
           if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
             directories=$(jq -nc --args '$ARGS.positional' -- "${all_dirs[@]}")
@@ -76,6 +79,9 @@ jobs:
             fi
             if [[ "${{ steps.filter.outputs.aws_identity_center }}" == "true" ]]; then
               dirs+=("infra/aws/identity-center")
+            fi
+            if [[ "${{ steps.filter.outputs.aws_accounts_research }}" == "true" ]]; then
+              dirs+=("infra/aws/accounts/research")
             fi
             directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi

--- a/infra/aws/accounts/research/main.tf
+++ b/infra/aws/accounts/research/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "natsukium-tfstate"
+    encrypt      = true
+    key          = "aws/accounts/research/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
+}
+
+# Account ID is plaintext per repo convention (it's already in the
+# organization stack outputs). Hardcoding it lets the provider config
+# resolve at init without needing a data source.
+locals {
+  research_account_id = "907199504666"
+}
+
+# Provider assumes the admin role AWS Organizations auto-creates in the
+# member account. Both apply_role and plan_role have sts:AssumeRole on
+# this target via OIDC stack policies.
+provider "aws" {
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.research_account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# Bucket name carries the owning account ID as prefix for global
+# uniqueness without relying on a user-handle namespace.
+resource "aws_s3_bucket" "experiments" {
+  bucket = "${local.research_account_id}-experiments"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "experiments" {
+  bucket = aws_s3_bucket.experiments.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "experiments" {
+  bucket                  = aws_s3_bucket.experiments.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "experiments" {
+  bucket = aws_s3_bucket.experiments.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+output "experiments_bucket" {
+  value = aws_s3_bucket.experiments.id
+}


### PR DESCRIPTION
## Summary
New stack at \`infra/aws/accounts/research\` provisions resources inside the research member account by assuming \`OrganizationAccountAccessRole\`. First resource is an S3 bucket for experiment results.

### Bucket configuration
| Property | Value |
|---|---|
| Name | \`907199504666-experiments\` |
| Region | \`ap-northeast-1\` |
| Versioning | Enabled |
| Public access | All blocked |
| Encryption | SSE-S3 (AES256) |
| Lifecycle | \`prevent_destroy = true\` |

The account ID prefix follows AWS's multi-account naming pattern: guaranteed globally unique without relying on a personal-handle namespace, and self-documenting about which account owns the bucket.

### Workflow
Filter \`aws_accounts_research\` added so changes under the new directory route through plan/apply like existing stacks.

## Dependencies
Stacked on #708 which grants \`apply_role\` and \`plan_role\` the \`sts:AssumeRole\` permission on research's \`OrganizationAccountAccessRole\`. CI here cannot succeed until #708 is merged and applied.

## Test plan
- [ ] CI plan shows 4 creates: bucket, versioning config, public-access-block, SSE configuration
- [ ] After merge, CI apply completes
- [ ] Bucket appears in research account console (region ap-northeast-1)
- [ ] Object upload via SSO portal → research → S3 succeeds for both \`tomoya\` (admin) and \`hikari\` (PowerUser)