### PR TITLE
fix(infra/oidc): include plan-* policies in apply_role IAM scope

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -168,6 +168,7 @@ data "aws_iam_policy_document" "apply_iam_oidc" {
       "arn:aws:iam::*:role/github-actions-*",
       "arn:aws:iam::*:policy/tfstate-*",
       "arn:aws:iam::*:policy/apply-*",
+      "arn:aws:iam::*:policy/plan-*",
       "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com",
     ]
   }


### PR DESCRIPTION
## Summary
The CI apply for #708 on main failed with:

\`\`\`
AccessDenied: User: github-actions-terraform-apply is not authorized to perform:
  iam:CreatePolicy on resource: policy plan-research-account-assume-role
\`\`\`

\`apply-iam-oidc-stack\` policy's resource ARN scope only covered \`tfstate-*\` and \`apply-*\` policy names. The new \`plan-research-account-assume-role\` policy added in #708 starts with \`plan-\` and falls outside that scope.

This PR extends the scope to also include \`policy/plan-*\`, mirroring how \`tfstate-*\` already covers both \`tfstate-read\` (used by plan_role) and \`tfstate-write\` (used by apply_role).

## Bootstrap order issue
Since #708's apply failed partway, AWS state is now inconsistent with main's terraform code: \`apply-research-account-assume-role\` may have been created but \`plan-research-account-assume-role\` was not.

After merging this PR, one manual apply with personal admin is needed to converge AWS state with the post-merge code (the new scope + the two assume-role policies). Subsequent CI applies will then work.

\`\`\`fish
aws-vault exec <personal-admin> -- terraform -chdir=infra/global/oidc apply
\`\`\`

## Test plan
- [ ] Local plan diff matches expectations (single CreatePolicyVersion on apply-iam-oidc-stack)
- [ ] Manual local apply succeeds; converges AWS state including the two assume policies
- [ ] After merge, CI apply on main is a no-op
- [ ] Rebased #709 CI plan/apply succeeds with the new permissions in place