### PR TITLE
feat(infra/aws): add security baseline with CloudTrail and Budgets

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -44,6 +44,8 @@ jobs:
               - 'infra/aws/identity-center/**'
             aws_accounts_research:
               - 'infra/aws/accounts/research/**'
+            aws_security_baseline:
+              - 'infra/aws/security-baseline/**'
             shared:
               - 'flake.lock'
               - '.github/workflows/terraform.yml'
@@ -57,6 +59,7 @@ jobs:
             "infra/aws/organization"
             "infra/aws/identity-center"
             "infra/aws/accounts/research"
+            "infra/aws/security-baseline"
           )
           if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
             directories=$(jq -nc --args '$ARGS.positional' -- "${all_dirs[@]}")
@@ -82,6 +85,9 @@ jobs:
             fi
             if [[ "${{ steps.filter.outputs.aws_accounts_research }}" == "true" ]]; then
               dirs+=("infra/aws/accounts/research")
+            fi
+            if [[ "${{ steps.filter.outputs.aws_security_baseline }}" == "true" ]]; then
+              dirs+=("infra/aws/security-baseline")
             fi
             directories=$(jq -nc --args '$ARGS.positional' -- "${dirs[@]}")
           fi

--- a/infra/aws/security-baseline/budgets.tf
+++ b/infra/aws/security-baseline/budgets.tf
@@ -1,0 +1,55 @@
+locals {
+  # Notification target only; not a login ID or password reset path, so
+  # treated as a semi-public identifier per the repo's secrets convention.
+  alert_email = "tomoya.otabi@gmail.com"
+
+  budgets = {
+    management = {
+      account_id = data.aws_caller_identity.current.account_id
+      limit      = "5"
+    }
+    research = {
+      account_id = data.terraform_remote_state.organization.outputs.research_account_id
+      limit      = "10"
+    }
+  }
+}
+
+# Per-account monthly cost budgets with email alerts. cost_filter by
+# LinkedAccount means each budget tracks spend within a single member
+# account, even though all budgets live in the management account where
+# consolidated billing aggregates.
+resource "aws_budgets_budget" "monthly" {
+  for_each = local.budgets
+
+  name         = "${each.key}-monthly"
+  budget_type  = "COST"
+  limit_amount = each.value.limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_filter {
+    name   = "LinkedAccount"
+    values = [each.value.account_id]
+  }
+
+  dynamic "notification" {
+    for_each = toset(["50", "80", "100"])
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = tonumber(notification.value)
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = [local.alert_email]
+    }
+  }
+
+  # Forecasted overrun gives a heads-up before the budget is actually hit.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [local.alert_email]
+  }
+}

--- a/infra/aws/security-baseline/cloudtrail.tf
+++ b/infra/aws/security-baseline/cloudtrail.tf
@@ -1,0 +1,111 @@
+resource "aws_s3_bucket" "cloudtrail_logs" {
+  bucket = "${data.aws_caller_identity.current.account_id}-cloudtrail-logs"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail_logs" {
+  bucket                  = aws_s3_bucket.cloudtrail_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# Audit logs may be needed retroactively, so no expiration. Transition to
+# Glacier after 90 days for cost — at-rest access is still possible, just
+# slower.
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+
+  rule {
+    id     = "archive-to-glacier"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+}
+
+# Bucket policy following the AWS-documented format for organization
+# trails: log paths are namespaced under the org ID rather than per
+# account ID, so the allow rule must reference the org ID.
+data "aws_iam_policy_document" "cloudtrail_logs_bucket" {
+  statement {
+    sid = "CloudTrailAclCheck"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.cloudtrail_logs.arn]
+  }
+
+  statement {
+    sid = "CloudTrailWrite"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = ["s3:PutObject"]
+    resources = [
+      "${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.terraform_remote_state.organization.outputs.organization_id}/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail_logs" {
+  bucket = aws_s3_bucket.cloudtrail_logs.id
+  policy = data.aws_iam_policy_document.cloudtrail_logs_bucket.json
+}
+
+# Organization trail captures API activity from every member account
+# (including future ones) into a single bucket in the management account.
+# is_multi_region_trail ensures regional services are also covered without
+# needing one trail per region.
+resource "aws_cloudtrail" "org_trail" {
+  name           = "org-trail"
+  s3_bucket_name = aws_s3_bucket.cloudtrail_logs.id
+
+  is_organization_trail         = true
+  is_multi_region_trail         = true
+  include_global_service_events = true
+  enable_log_file_validation    = true
+
+  depends_on = [aws_s3_bucket_policy.cloudtrail_logs]
+}
+
+output "cloudtrail_logs_bucket" {
+  value = aws_s3_bucket.cloudtrail_logs.id
+}
+
+output "org_trail_arn" {
+  value = aws_cloudtrail.org_trail.arn
+}

--- a/infra/aws/security-baseline/main.tf
+++ b/infra/aws/security-baseline/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "natsukium-tfstate"
+    encrypt      = true
+    key          = "aws/security-baseline/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "organization" {
+  backend = "s3"
+  config = {
+    bucket = "natsukium-tfstate"
+    key    = "aws/organization/terraform.tfstate"
+    region = "us-east-2"
+  }
+}


### PR DESCRIPTION
## Summary
New stack at \`infra/aws/security-baseline\` provisions the management-account half of the security baseline.

### CloudTrail org trail
- Multi-region organization trail captures API activity from every member account (including future ones) into one bucket in the management account
- S3 bucket \`233656399216-cloudtrail-logs\` with versioning, SSE-S3, public access blocked, \`prevent_destroy\`
- Lifecycle transitions to Glacier after 90 days, no expiration so audit logs remain retroactively accessible
- Log file validation enabled

### Budgets
- Per-account monthly cost budgets in the management account, scoped by \`LinkedAccount\` cost filter
- Management \$5/month, research \$10/month
- Alerts at 50/80/100% actual + 100% forecasted, emailed to the address in \`secrets.yaml\` (sops-encrypted)

### Workflow
Filter \`aws_security_baseline\` added.

## Dependencies
Stacked on #712 which grants \`apply_role\` the CloudTrail, Budgets, and bucket management permissions.

## Test plan
- [ ] CI plan shows: 2 budgets, 1 CloudTrail, 1 S3 bucket + 5 supporting resources (versioning, PAB, encryption, lifecycle, policy)
- [ ] After merge, CI apply completes
- [ ] CloudTrail console shows org-trail as multi-region, enabled
- [ ] S3 bucket contains \`AWSLogs/<org-id>/...\` paths shortly after apply
- [ ] Budget alerts arrive at \`tomoya.otabi@gmail.com\` when thresholds are crossed (verify on next month boundary)