### PR TITLE
fix(infra/aws): allow management account-id path in CloudTrail bucket

### DIFF
--- a/infra/aws/security-baseline/cloudtrail.tf
+++ b/infra/aws/security-baseline/cloudtrail.tf
@@ -70,7 +70,11 @@ data "aws_iam_policy_document" "cloudtrail_logs_bucket" {
       identifiers = ["cloudtrail.amazonaws.com"]
     }
     actions = ["s3:PutObject"]
+    # Org trails write under the org-id-namespaced path, but CloudTrail's
+    # preflight CreateTrail check additionally validates writes at the
+    # management account's account-id path; both must be allowed.
     resources = [
+      "${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
       "${aws_s3_bucket.cloudtrail_logs.arn}/AWSLogs/${data.terraform_remote_state.organization.outputs.organization_id}/*",
     ]
     condition {


### PR DESCRIPTION
## Summary
\`CreateTrail\` failed during #713's CI apply with:

\`\`\`
InsufficientS3BucketPolicyException: Incorrect S3 bucket policy is detected for bucket: 233656399216-cloudtrail-logs
\`\`\`

The bucket policy followed AWS's documented org-trail example (\`s3:PutObject\` on \`AWSLogs/<org-id>/*\`), but CloudTrail's preflight \`CreateTrail\` check on an organization trail additionally validates writes against the management account's legacy \`AWSLogs/<management-account-id>/*\` path.

This PR adds the management account-id resource alongside the org-id one. Both paths stay under CloudTrail's namespace, so the policy remains scoped.

## Bootstrap order
\`#713\`'s apply created the bucket and supporting resources but failed before the trail. After this fix merges, CI re-applies; the trail creation should succeed on the second attempt because the bucket already exists with the corrected policy.

## Test plan
- [ ] CI plan diff is a single \`update in-place\` on \`aws_s3_bucket_policy.cloudtrail_logs\` + one \`create\` for \`aws_cloudtrail.org_trail\`
- [ ] CI apply completes
- [ ] CloudTrail console shows \`org-trail\` enabled and multi-region
- [ ] S3 bucket starts accumulating logs under \`AWSLogs/<org-id>/\` within minutes