### PR TITLE
fix(infra/aws): create CloudTrail service-linked role explicitly

### DIFF
--- a/infra/aws/security-baseline/cloudtrail.tf
+++ b/infra/aws/security-baseline/cloudtrail.tf
@@ -90,6 +90,14 @@ resource "aws_s3_bucket_policy" "cloudtrail_logs" {
   policy = data.aws_iam_policy_document.cloudtrail_logs_bucket.json
 }
 
+# Service-linked role for CloudTrail. Enabling cloudtrail.amazonaws.com
+# as a trusted service in Organizations does not auto-provision the SLR;
+# without it, CreateTrail with is_organization_trail=true fails with
+# InsufficientDependencyServiceAccessPermissionException.
+resource "aws_iam_service_linked_role" "cloudtrail" {
+  aws_service_name = "cloudtrail.amazonaws.com"
+}
+
 # Organization trail captures API activity from every member account
 # (including future ones) into a single bucket in the management account.
 # is_multi_region_trail ensures regional services are also covered without
@@ -103,7 +111,10 @@ resource "aws_cloudtrail" "org_trail" {
   include_global_service_events = true
   enable_log_file_validation    = true
 
-  depends_on = [aws_s3_bucket_policy.cloudtrail_logs]
+  depends_on = [
+    aws_s3_bucket_policy.cloudtrail_logs,
+    aws_iam_service_linked_role.cloudtrail,
+  ]
 }
 
 output "cloudtrail_logs_bucket" {


### PR DESCRIPTION
## Summary
\`CreateTrail\` with \`is_organization_trail=true\` failed in #715's CI apply with:

\`\`\`
InsufficientDependencyServiceAccessPermissionException: AWS CloudTrail cannot
create resources for your organization because access to one or more required
APIs has been denied.
\`\`\`

Investigation: cloudtrail.amazonaws.com IS enabled as trusted service in Organizations (verified via \`organizations:ListAWSServiceAccessForOrganization\`), but the \`AWSServiceRoleForCloudTrail\` SLR was missing in the management account. Some services auto-provision their SLR when trusted access is enabled; CloudTrail does not for org trails.

This PR adds an explicit \`aws_iam_service_linked_role.cloudtrail\` resource and makes the trail depend on it. \`apply_role\` already has \`iam:CreateServiceLinkedRole\` on \`aws-service-role/*\` via the existing \`apply-iam-service-linked-role\` policy, so this can apply via CI without further perm changes.

## Test plan
- [ ] CI plan shows the new SLR resource + dependency on the existing trail
- [ ] CI apply creates the SLR first, then the trail succeeds
- [ ] CloudTrail console shows \`org-trail\` as enabled and multi-region
- [ ] S3 bucket starts accumulating logs under \`AWSLogs/<org-id>/\`