### PR TITLE
fix(infra/oidc): grant apply_role read actions for service-linked roles

### DIFF
--- a/infra/global/oidc/iam-apply.tf
+++ b/infra/global/oidc/iam-apply.tf
@@ -85,6 +85,12 @@ data "aws_iam_policy_document" "apply_iam_slr" {
       "iam:CreateServiceLinkedRole",
       "iam:DeleteServiceLinkedRole",
       "iam:GetServiceLinkedRoleDeletionStatus",
+      # Get/List actions are needed by terraform refresh after creating an
+      # SLR; without them apply fails right after CreateServiceLinkedRole
+      # with iam:GetRole denied.
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
     ]
     resources = ["arn:aws:iam::*:role/aws-service-role/*"]
   }


### PR DESCRIPTION
## Summary
The CloudTrail SLR creation in #716 succeeded but the subsequent terraform refresh failed with:

\`\`\`
Error: reading IAM Service Linked Role (...AWSServiceRoleForCloudTrail):
AccessDenied: iam:GetRole on AWSServiceRoleForCloudTrail
\`\`\`

The \`apply-iam-service-linked-role\` policy only allowed write actions (Create/Delete/GetDeletionStatus). Terraform's post-create refresh needs \`iam:GetRole\` on the new SLR ARN to populate state, and apply_role lacked it.

This PR extends the policy with read actions (\`iam:GetRole\`, \`iam:ListAttachedRolePolicies\`, \`iam:ListRolePolicies\`) on the same \`aws-service-role/*\` scope. apply_role still cannot inspect arbitrary IAM roles.

## ⚠️ Recovery state required
After #716's apply, AWS state is partial:
- \`AWSServiceRoleForCloudTrail\` SLR was created in IAM
- Terraform state in \`aws/security-baseline/\` does NOT have it (refresh errored before persisting)
- The trail itself was not created

A naive CI apply after this PR merges will fail with \`EntityAlreadyExists\` when trying to create the SLR again. Recovery requires \`terraform import\` of the existing SLR before the next apply.

## Recovery steps (after merge)

\`\`\`fish
# Pull the merged main
git switch main && git pull

# Import the orphaned SLR into state
aws-vault exec default -- terraform -chdir=infra/aws/security-baseline init
aws-vault exec default -- terraform -chdir=infra/aws/security-baseline import \\
  aws_iam_service_linked_role.cloudtrail \\
  arn:aws:iam::233656399216:role/aws-service-role/cloudtrail.amazonaws.com/AWSServiceRoleForCloudTrail

# Trigger re-run of last failed CI run
gh run rerun <run-id> --failed
\`\`\`

After import, the refresh in CI succeeds (with the new \`iam:GetRole\` perm) and the trail finally gets created.

## Test plan
- [ ] CI plan shows single update on \`apply-iam-service-linked-role\` policy
- [ ] After merge + manual import + CI rerun: trail visible in CloudTrail console