### PR TITLE
chore(ci): push build artifacts to self-hosted Attic instead of Cachix

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,11 +1,8 @@
-name: Setup Nix with Cachix
-description: Setup Nix environment with Cachix configuration
+name: Setup Nix with Attic
+description: Setup Nix environment with Attic binary cache
 inputs:
-  signingKey:
-    description: Cachix signing key
-    required: false
-  authToken:
-    description: Cachix auth token
+  token:
+    description: Attic auth token
     required: true
 runs:
   using: composite
@@ -15,10 +12,13 @@ runs:
       # so nixbuild/nix-quick-install-action cannot be used
       # https://github.com/nix-community/cache-nix-action/issues/60#issuecomment-3561402982
       uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-    - name: Setup cachix
-      uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
       with:
-        name: natsukium
-        signingKey: ${{ inputs.signingKey }}
-        authToken: ${{ inputs.authToken }}
-        extraPullNames: nix-community
+        extra_nix_config: |
+          extra-substituters = https://nix-community.cachix.org
+          extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+    - name: Setup attic
+      uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+      with:
+        endpoint: https://cache.natsukium.com
+        cache: dotfiles
+        token: ${{ inputs.token }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
         with:
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Build documentation
         run: nix build .#html
       - name: Upload artifact

--- a/.github/workflows/pr-dix-diff.yml
+++ b/.github/workflows/pr-dix-diff.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
         with:
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          token: ${{ secrets.ATTIC_TOKEN }}
       - uses: natsukium/nix-diff-action@b5c316c6cafc8470037d7f330b178aaeeba96ba4 # v1.1.0
         with:
           attributes: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
         with:
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          token: ${{ secrets.ATTIC_TOKEN }}
       - uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
         with:
           role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-nix
         with:
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Check flake
         run: nix flake check --no-build --all-systems --keep-going
   build:
@@ -90,7 +90,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
         if: needs.check.result == 'success'
         with:
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          token: ${{ secrets.ATTIC_TOKEN }}
       - name: Create /run for darwin
         if: needs.check.result == 'success' && matrix.os == 'macos-latest'
         run: |

--- a/configuration.org
+++ b/configuration.org
@@ -841,12 +841,12 @@ configured in their =nix.conf= or system configuration.
 #+NAME: nix-config
 #+begin_src nix
 extra-substituters = [
-  "https://natsukium.cachix.org"
+  "https://cache.natsukium.com/dotfiles"
   "https://nix-community.cachix.org"
 ];
 
 extra-trusted-public-keys = [
-  "natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI="
+  "dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols="
   "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
 ];
 #+end_src
@@ -863,9 +863,9 @@ Alternatively, Flox's binary cache can be used for CUDA packages. As of Septembe
 partnered with NVIDIA to obtain redistribution rights. See
 https://discourse.nixos.org/t/nix-flox-nvidia-opening-up-cuda-redistribution-on-nix/69189
 
-***** natsukium.cachix.org
+***** cache.natsukium.com
 
-Personal binary cache containing outputs from this flake. Packages not available in the
+Self-hosted Attic cache containing outputs from this flake. Packages not available in the
 official =cache.nixos.org= or =nix-community.cachix.org= are built on GitHub Actions and
 pushed here.
 

--- a/flake.nix
+++ b/flake.nix
@@ -163,12 +163,12 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://natsukium.cachix.org"
+      "https://cache.natsukium.com/dotfiles"
       "https://nix-community.cachix.org"
     ];
 
     extra-trusted-public-keys = [
-      "natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI="
+      "dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };

--- a/modules/configuration.org
+++ b/modules/configuration.org
@@ -160,20 +160,24 @@ nix.settings.warn-dirty = false;
 
 **** Binary Caches
 
-Two binary caches are configured: =natsukium= holds pre-built artifacts for this dotfiles
-repository (CI-built system closures and custom packages), and =nix-community= provides
-caches for community projects including NVIDIA/CUDA packages and other
-nix-community-maintained derivations.
+Three binary caches are configured. =cache.natsukium.com= is a self-hosted Attic
+instance (running on serengeti, backed by Cloudflare R2) that CI pushes this flake's
+pre-built artifacts to. It took over from =natsukium.cachix.org= because the dotfiles
+closures outgrew Cachix's storage limits.
+=nix-community= provides caches for community projects including
+NVIDIA/CUDA packages and other nix-community-maintained derivations.
 
 #+NAME: nix-substituters
 #+begin_src nix
 nix.settings = {
   substituters = [
+    "https://cache.natsukium.com/dotfiles"
     "https://natsukium.cachix.org"
     "https://nix-community.cachix.org"
   ];
 
   trusted-public-keys = [
+    "dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols="
     "natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI="
     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
   ];

--- a/modules/shared/nix/default.nix
+++ b/modules/shared/nix/default.nix
@@ -48,11 +48,13 @@ in
 
       nix.settings = {
         substituters = [
+          "https://cache.natsukium.com/dotfiles"
           "https://natsukium.cachix.org"
           "https://nix-community.cachix.org"
         ];
 
         trusted-public-keys = [
+          "dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols="
           "natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI="
           "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         ];

--- a/po/dotfiles.pot
+++ b/po/dotfiles.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-28 00:51+0900\n"
+"POT-Creation-Date: 2026-05-30 18:42+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -409,8 +409,8 @@ msgstr ""
 
 #. type: heading ***
 #: configuration.org:71 modules/flake/features/emacs/init.org:607
-#: modules/configuration.org:71 modules/configuration.org:321
-#: modules/configuration.org:514
+#: modules/configuration.org:71 modules/configuration.org:325
+#: modules/configuration.org:518
 #, no-wrap
 msgid "Configuration"
 msgstr ""
@@ -1777,7 +1777,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "extra-substituters = [\n"
-"  \"https://natsukium.cachix.org\"\n"
+"  \"https://cache.natsukium.com/dotfiles\"\n"
 "  \"https://nix-community.cachix.org\"\n"
 "];"
 msgstr ""
@@ -1787,7 +1787,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "extra-trusted-public-keys = [\n"
-"  \"natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI=\"\n"
+"  \"dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols=\"\n"
 "  "
 "\"nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=\"\n"
 "];"
@@ -1827,13 +1827,13 @@ msgstr ""
 #. type: heading *****
 #: configuration.org:866
 #, no-wrap
-msgid "natsukium.cachix.org"
+msgid "cache.natsukium.com"
 msgstr ""
 
 #. type: paragraph
 #: configuration.org:868
 msgid ""
-"Personal binary cache containing outputs from this flake. Packages not "
+"Self-hosted Attic cache containing outputs from this flake. Packages not "
 "available in the official =cache.nixos.org= or =nix-community.cachix.org= "
 "are built on GitHub Actions and pushed here."
 msgstr ""
@@ -6130,7 +6130,7 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:20 modules/configuration.org:1221
+#: modules/configuration.org:20 modules/configuration.org:1225
 #, no-wrap
 msgid "Core Settings"
 msgstr ""
@@ -6176,7 +6176,7 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:55 modules/configuration.org:473
+#: modules/configuration.org:55 modules/configuration.org:477
 #, no-wrap
 msgid "Options"
 msgstr ""
@@ -6415,34 +6415,39 @@ msgstr ""
 #. type: paragraph
 #: modules/configuration.org:163
 msgid ""
-"Two binary caches are configured: =natsukium= holds pre-built artifacts for "
-"this dotfiles repository (CI-built system closures and custom packages), and "
-"=nix-community= provides caches for community projects including NVIDIA/CUDA "
-"packages and other nix-community-maintained derivations."
+"Three binary caches are configured. =cache.natsukium.com= is a self-hosted "
+"Attic instance (running on serengeti, backed by Cloudflare R2) that CI "
+"pushes this flake's pre-built artifacts to. It took over from "
+"=natsukium.cachix.org= because the dotfiles closures outgrew Cachix's "
+"storage limits.  =nix-community= provides caches for community projects "
+"including NVIDIA/CUDA packages and other nix-community-maintained "
+"derivations."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:168
+#: modules/configuration.org:170
 #, no-wrap
 msgid "nix-substituters"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:170
+#: modules/configuration.org:172
 #, no-wrap
 msgid ""
 "nix.settings = {\n"
 "  substituters = [\n"
+"    \"https://cache.natsukium.com/dotfiles\"\n"
 "    \"https://natsukium.cachix.org\"\n"
 "    \"https://nix-community.cachix.org\"\n"
 "  ];"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:176
+#: modules/configuration.org:179
 #, no-wrap
 msgid ""
 "  trusted-public-keys = [\n"
+"    \"dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols=\"\n"
 "    "
 "\"natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI=\"\n"
 "    "
@@ -6452,13 +6457,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:183
+#: modules/configuration.org:187
 #, no-wrap
 msgid "Sandbox"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:185
+#: modules/configuration.org:189
 msgid ""
 "The sandbox is set to =\"relaxed\"= on Darwin to avoid unexpected build "
 "failures. With =sandbox = true=, some packages fail to build on macOS due to "
@@ -6472,13 +6477,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:194
+#: modules/configuration.org:198
 #, no-wrap
 msgid "nix-sandbox"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:196
+#: modules/configuration.org:200
 #, no-wrap
 msgid ""
 "nix.settings.sandbox = if pkgs.stdenv.hostPlatform.isDarwin then \"relaxed\" "
@@ -6486,13 +6491,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:199
+#: modules/configuration.org:203
 #, no-wrap
 msgid "Trusted Users"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:201
+#: modules/configuration.org:205
 msgid ""
 "On macOS, administrative users belong to the =admin= group, not =wheel= "
 "(which only contains =root=). Without =@admin=, the primary user would not "
@@ -6500,13 +6505,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:205
+#: modules/configuration.org:209
 #, no-wrap
 msgid "nix-trusted-users"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:207
+#: modules/configuration.org:211
 #, no-wrap
 msgid ""
 "nix.settings.trusted-users = [\n"
@@ -6517,13 +6522,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:214
+#: modules/configuration.org:218
 #, no-wrap
 msgid "Extra Options"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:216
+#: modules/configuration.org:220
 msgid ""
 "Terminates builds that produce no output for 3600 seconds (1 hour). Some "
 "heavy builds (e.g., Chromium, kernel compilation, CUDA-based deep learning "
@@ -6533,13 +6538,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:221
+#: modules/configuration.org:225
 #, no-wrap
 msgid "nix-extra-options"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:223
+#: modules/configuration.org:227
 #, no-wrap
 msgid ""
 "nix.extraOptions = ''\n"
@@ -6548,13 +6553,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:228
+#: modules/configuration.org:232
 #, no-wrap
 msgid "Nixpkgs"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:230
+#: modules/configuration.org:234
 msgid ""
 "Nixpkgs configuration. =allowUnfree= is enabled by default. While free "
 "software is preferred where possible, strictly enforcing it is impractical — "
@@ -6564,7 +6569,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:242
+#: modules/configuration.org:246
 #, no-wrap
 msgid ""
 "{ config, lib, ... }:\n"
@@ -6583,7 +6588,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:256
+#: modules/configuration.org:260
 #, no-wrap
 msgid ""
 "  allowUnfree = mkOption {\n"
@@ -6596,7 +6601,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:264
+#: modules/configuration.org:268
 #, no-wrap
 msgid ""
 "  config = mkIf cfg.enable {\n"
@@ -6608,13 +6613,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:272
+#: modules/configuration.org:276
 #, no-wrap
 msgid "Distributed Builds"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:274
+#: modules/configuration.org:278
 msgid ""
 "[[https://nix.dev/manual/nix/latest/advanced-topics/distributed-builds][Distributed "
 "build]] configuration using Nix's built-in =buildMachines= support. This "
@@ -6623,7 +6628,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:278
+#: modules/configuration.org:282
 msgid ""
 "=nix.distributedBuilds= is set to =mkDefault true= here so that server "
 "profiles can override it to =false=. =nix.buildMachines= is harmless when "
@@ -6635,7 +6640,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:291
+#: modules/configuration.org:295
 #, no-wrap
 msgid ""
 "{\n"
@@ -6652,7 +6657,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:303
+#: modules/configuration.org:307
 #, no-wrap
 msgid ""
 "  <<build-machines-known-hosts>>\n"
@@ -6660,13 +6665,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:307
+#: modules/configuration.org:311
 #, no-wrap
 msgid "Protocol Selection"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:309
+#: modules/configuration.org:313
 msgid ""
 "The =ssh-ng= protocol is preferred over plain =ssh= because it supports "
 "content-addressed derivations and more efficient store path "
@@ -6677,13 +6682,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:314
+#: modules/configuration.org:318
 #, no-wrap
 msgid "build-machines-let"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:316
+#: modules/configuration.org:320
 #, no-wrap
 msgid ""
 "protocol = if (config.services ? hydra && config.services.hydra.enable) then "
@@ -6694,13 +6699,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:323
+#: modules/configuration.org:327
 #, no-wrap
 msgid "distributed-builds-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:325
+#: modules/configuration.org:329
 #, no-wrap
 msgid ""
 "nix = {\n"
@@ -6708,7 +6713,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:328
+#: modules/configuration.org:332
 #, no-wrap
 msgid ""
 "extraOptions = ''\n"
@@ -6717,7 +6722,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:332
+#: modules/configuration.org:336
 #, no-wrap
 msgid ""
 "  <<build-machines-list>>\n"
@@ -6725,13 +6730,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:336
+#: modules/configuration.org:340
 #, no-wrap
 msgid "Build Machines"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:338
+#: modules/configuration.org:342
 msgid ""
 "Each machine excludes itself from the build machine list (via "
 "=config.networking.hostName= checks) to avoid circular build delegation. The "
@@ -6740,7 +6745,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:343
+#: modules/configuration.org:347
 msgid ""
 "Machine capabilities (=maxJobs=, =system-features=) are referenced from each "
 "machine's configuration rather than hardcoded. See each machine's definition "
@@ -6749,13 +6754,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:347
+#: modules/configuration.org:351
 #, no-wrap
 msgid "build-machines-list"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:349
+#: modules/configuration.org:353
 #, no-wrap
 msgid ""
 "buildMachines =\n"
@@ -6818,13 +6823,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:407
+#: modules/configuration.org:411
 #, no-wrap
 msgid "SSH Known Hosts"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:409
+#: modules/configuration.org:413
 msgid ""
 "Distributed builds connect to remote machines over SSH, so each build "
 "machine's host key must be registered to avoid interactive verification "
@@ -6832,13 +6837,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:412
+#: modules/configuration.org:416
 #, no-wrap
 msgid "build-machines-known-hosts"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:414
+#: modules/configuration.org:418
 #, no-wrap
 msgid ""
 "programs.ssh.knownHosts = {\n"
@@ -6854,20 +6859,20 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:422
+#: modules/configuration.org:426
 #, no-wrap
 msgid "User-Level Settings"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:424
+#: modules/configuration.org:428
 msgid ""
 "User-level Nix settings, managed through home-manager because they belong to "
 "the user's environment rather than the system configuration."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:427
+#: modules/configuration.org:431
 msgid ""
 "XDG base directories are enabled to keep =~/.nix-defexpr= and "
 "=~/.nix-profile= under =~/.config/nix/= and =~/.local/state/nix/=, "
@@ -6875,7 +6880,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:431
+#: modules/configuration.org:435
 msgid ""
 "The =result= symlink is added to git ignores because =nix build= creates "
 "=result= symlinks in the project root by default, and these should never be "
@@ -6884,7 +6889,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:441
+#: modules/configuration.org:445
 #, no-wrap
 msgid ""
 "{ config, ... }:\n"
@@ -6893,7 +6898,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:445
+#: modules/configuration.org:449
 #, no-wrap
 msgid ""
 "  programs.git.ignores = [ \"result\" ];\n"
@@ -6901,19 +6906,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:449 modules/configuration.org:557
+#: modules/configuration.org:453 modules/configuration.org:561
 #, no-wrap
 msgid "Networking"
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:451
+#: modules/configuration.org:455
 #, no-wrap
 msgid "Tailscale"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:453
+#: modules/configuration.org:457
 msgid ""
 "Opinionated Tailscale VPN configuration for NixOS systems. This module "
 "provides sensible defaults for running Tailscale with MagicDNS, SSH access, "
@@ -6921,7 +6926,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:462
+#: modules/configuration.org:466
 #, no-wrap
 msgid ""
 "{ config, lib, ... }:\n"
@@ -6933,7 +6938,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:469
+#: modules/configuration.org:473
 #, no-wrap
 msgid ""
 "  <<tailscale-config>>\n"
@@ -6941,18 +6946,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:475
+#: modules/configuration.org:479
 msgid "Module options for controlling Tailscale behavior."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:477
+#: modules/configuration.org:481
 #, no-wrap
 msgid "tailscale-options"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:479
+#: modules/configuration.org:483
 #, no-wrap
 msgid ""
 "options.my.services.tailscale = {\n"
@@ -6960,7 +6965,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:482
+#: modules/configuration.org:486
 #, no-wrap
 msgid ""
 "  <<configureResolver-option>>\n"
@@ -6968,13 +6973,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:486
+#: modules/configuration.org:490
 #, no-wrap
 msgid "configureResolver"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:488
+#: modules/configuration.org:492
 msgid ""
 "Desktop systems may experience DNS resolution failures after "
 "suspend/resume. When the system resumes, external domain resolution (e.g., "
@@ -6983,7 +6988,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:492
+#: modules/configuration.org:496
 msgid ""
 "Enabling =configureResolver= activates systemd-resolved, which helps "
 "mitigate DNS resolution issues after suspend/resume. While this doesn't "
@@ -6992,14 +6997,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:496
+#: modules/configuration.org:500
 msgid ""
 "For headless servers, this option is typically unnecessary because servers "
 "don't suspend, and thus never encounter this resume-related DNS bug."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:499
+#: modules/configuration.org:503
 msgid ""
 "See "
 "[[https://github.com/tailscale/tailscale/issues/4254][tailscale/tailscale#4254]] "
@@ -7007,13 +7012,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:501
+#: modules/configuration.org:505
 #, no-wrap
 msgid "configureResolver-option"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:503
+#: modules/configuration.org:507
 #, no-wrap
 msgid ""
 "configureResolver = lib.mkOption {\n"
@@ -7029,13 +7034,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:516
+#: modules/configuration.org:520
 #, no-wrap
 msgid "tailscale-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:518
+#: modules/configuration.org:522
 #, no-wrap
 msgid ""
 "config = lib.mkIf cfg.enable (\n"
@@ -7045,13 +7050,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:523
+#: modules/configuration.org:527
 #, no-wrap
 msgid "<<tailscale-networking>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:525
+#: modules/configuration.org:529
 #, no-wrap
 msgid ""
 "      <<tailscale-secrets>>\n"
@@ -7062,18 +7067,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:532
+#: modules/configuration.org:536
 #, no-wrap
 msgid "Service Settings"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:534
+#: modules/configuration.org:538
 msgid "Core Tailscale service configuration."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:536
+#: modules/configuration.org:540
 msgid ""
 "=useRoutingFeatures = \"server\"= enables this machine to act as a subnet "
 "router or exit node.  All machines in this configuration can potentially "
@@ -7082,7 +7087,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:540
+#: modules/configuration.org:544
 msgid ""
 "=authKeyFile= points to a SOPS-managed secret containing a Tailscale auth "
 "key. Using auth keys enables unattended authentication, which is essential "
@@ -7090,7 +7095,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:544
+#: modules/configuration.org:548
 msgid ""
 "=--ssh= enables Tailscale SSH, allowing SSH access over the Tailscale "
 "network without managing SSH keys or exposing port 22 to the public "
@@ -7098,13 +7103,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:547
+#: modules/configuration.org:551
 #, no-wrap
 msgid "tailscale-service"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:549
+#: modules/configuration.org:553
 #, no-wrap
 msgid ""
 "services.tailscale = {\n"
@@ -7116,12 +7121,12 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:559
+#: modules/configuration.org:563
 msgid "Firewall and DNS configuration for Tailscale integration."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:561
+#: modules/configuration.org:565
 msgid ""
 "The =tailscale0= interface is trusted because all traffic on this interface "
 "is authenticated by Tailscale. This allows services to be exposed only to "
@@ -7129,7 +7134,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:565
+#: modules/configuration.org:569
 msgid ""
 "=100.100.100.100= is Tailscale's MagicDNS resolver, enabling resolution of "
 "tailnet hostnames (e.g., =hostname.tail4108.ts.net=). =8.8.8.8= provides "
@@ -7138,20 +7143,20 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:569
+#: modules/configuration.org:573
 msgid ""
 "The search domain is the tailnet domain, allowing short hostnames (e.g., "
 "=ssh manyara= instead of =ssh manyara.tail4108.ts.net=)."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:572
+#: modules/configuration.org:576
 #, no-wrap
 msgid "tailscale-networking"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:574
+#: modules/configuration.org:578
 #, no-wrap
 msgid ""
 "networking = {\n"
@@ -7168,38 +7173,38 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:587
+#: modules/configuration.org:591
 #, no-wrap
 msgid "Secrets"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:589
+#: modules/configuration.org:593
 msgid ""
 "SOPS secret declaration for the Tailscale auth key. The actual key is stored "
 "encrypted in the repository's secrets file and decrypted at activation time."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:592
+#: modules/configuration.org:596
 #, no-wrap
 msgid "tailscale-secrets"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:594
+#: modules/configuration.org:598
 #, no-wrap
 msgid "sops.secrets.tailscale-authkey = { };"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:597
+#: modules/configuration.org:601
 #, no-wrap
 msgid "Resolver"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:599
+#: modules/configuration.org:603
 msgid ""
 "Conditional systemd-resolved configuration. Only enabled when "
 "=configureResolver= is true, typically on desktop systems that "
@@ -7207,13 +7212,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:602
+#: modules/configuration.org:606
 #, no-wrap
 msgid "tailscale-resolver"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:604
+#: modules/configuration.org:608
 #, no-wrap
 msgid ""
 "(lib.mkIf cfg.configureResolver {\n"
@@ -7222,13 +7227,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:609
+#: modules/configuration.org:613
 #, no-wrap
 msgid "Shell"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:611
+#: modules/configuration.org:615
 msgid ""
 "Interactive shells and scripting shells serve different purposes. An "
 "interactive shell does not need to be POSIX-compatible — what matters is "
@@ -7236,13 +7241,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:615
+#: modules/configuration.org:619
 #, no-wrap
 msgid "Fish"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:617
+#: modules/configuration.org:621
 msgid ""
 "Fish is the primary interactive shell, chosen for its out-of-the-box "
 "experience: syntax highlighting, autosuggestions, and tab completions work "
@@ -7252,7 +7257,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:628
+#: modules/configuration.org:632
 #, no-wrap
 msgid ""
 "{ pkgs, ... }:\n"
@@ -7262,25 +7267,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:633
+#: modules/configuration.org:637
 #, no-wrap
 msgid "<<fish-interactive-shell-init>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:635
+#: modules/configuration.org:639
 #, no-wrap
 msgid "<<fish-abbreviations>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:637
+#: modules/configuration.org:641
 #, no-wrap
 msgid "<<fish-functions>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:639
+#: modules/configuration.org:643
 #, no-wrap
 msgid ""
 "    <<fish-plugins>>\n"
@@ -7289,26 +7294,26 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:644
+#: modules/configuration.org:648
 #, no-wrap
 msgid "Interactive Shell Init"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:646
+#: modules/configuration.org:650
 msgid ""
 "Settings applied when fish starts an interactive session: keybindings, "
 "plugin configuration, environment variables, and shell integrations."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:649
+#: modules/configuration.org:653
 #, no-wrap
 msgid "fish-interactive-shell-init"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:651
+#: modules/configuration.org:655
 #, no-wrap
 msgid ""
 "interactiveShellInit = ''\n"
@@ -7316,25 +7321,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:654
+#: modules/configuration.org:658
 #, no-wrap
 msgid "<<fish-done-config>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:656
+#: modules/configuration.org:660
 #, no-wrap
 msgid "<<fish-pinentry>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:658
+#: modules/configuration.org:662
 #, no-wrap
 msgid "<<fish-extra-abbrs>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:660
+#: modules/configuration.org:664
 #, no-wrap
 msgid ""
 "  <<fish-any-nix-shell>>\n"
@@ -7342,38 +7347,38 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:664
+#: modules/configuration.org:668
 #, no-wrap
 msgid "Keybindings"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:666
+#: modules/configuration.org:670
 msgid ""
 "=Ctrl+S= is bound to =zi= ([[https://github.com/ajeetdsouza/zoxide][zoxide]] "
 "interactive mode) for fuzzy directory jumping."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:668
+#: modules/configuration.org:672
 #, no-wrap
 msgid "fish-keybindings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:670
+#: modules/configuration.org:674
 #, no-wrap
 msgid "bind \\cs zi"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:673
+#: modules/configuration.org:677
 #, no-wrap
 msgid "Pinentry"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:675
+#: modules/configuration.org:679
 msgid ""
 "When connected via SSH, GPG's pinentry is switched to the curses (terminal) "
 "variant.  The default graphical pinentry cannot display on a remote session "
@@ -7384,13 +7389,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:680
+#: modules/configuration.org:684
 #, no-wrap
 msgid "fish-pinentry"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:683
+#: modules/configuration.org:687
 #, no-wrap
 msgid ""
 "if test \"$SSH_CONNECTION\" != \"\"\n"
@@ -7399,13 +7404,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:688
+#: modules/configuration.org:692
 #, no-wrap
 msgid "Extra Abbreviations"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:690
+#: modules/configuration.org:694
 msgid ""
 "Position-aware "
 "[[https://fishshell.com/docs/current/cmds/abbr.html][abbreviations]] that "
@@ -7415,13 +7420,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:693
+#: modules/configuration.org:697
 #, no-wrap
 msgid "fish-extra-abbrs"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:696
+#: modules/configuration.org:700
 #, no-wrap
 msgid ""
 "abbr -a L --position anywhere --set-cursor \"% | less\"\n"
@@ -7432,13 +7437,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:702
+#: modules/configuration.org:706
 #, no-wrap
 msgid "any-nix-shell"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:704
+#: modules/configuration.org:708
 msgid ""
 "[[https://github.com/haslersn/any-nix-shell][any-nix-shell]] keeps fish as "
 "the interactive shell inside =nix shell= and =nix develop= "
@@ -7449,31 +7454,31 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:710
+#: modules/configuration.org:714
 #, no-wrap
 msgid "fish-any-nix-shell"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:712
+#: modules/configuration.org:716
 #, no-wrap
 msgid "${pkgs.any-nix-shell}/bin/any-nix-shell fish | source"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:715
+#: modules/configuration.org:719
 #, no-wrap
 msgid "Abbreviations"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:717
+#: modules/configuration.org:721
 #, no-wrap
 msgid "fish-abbreviations"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:719
+#: modules/configuration.org:723
 #, no-wrap
 msgid ""
 "shellAbbrs = {\n"
@@ -7481,7 +7486,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:722
+#: modules/configuration.org:726
 #, no-wrap
 msgid ""
 "  <<fish-abbr-nix>>\n"
@@ -7489,31 +7494,31 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:726
+#: modules/configuration.org:730
 #, no-wrap
 msgid "General"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:728
+#: modules/configuration.org:732
 #, no-wrap
 msgid "fish-abbr-general"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:731
+#: modules/configuration.org:735
 #, no-wrap
 msgid "l = \"ls\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:734
+#: modules/configuration.org:738
 #, no-wrap
 msgid "Nix Remote Build"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:736
+#: modules/configuration.org:740
 msgid ""
 "Abbreviations for specifying Nix build target systems, primarily used when "
 "working on nixpkgs. Each abbreviation expands to =--system <triple>= and "
@@ -7525,13 +7530,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:743
+#: modules/configuration.org:747
 #, no-wrap
 msgid "fish-abbr-nix"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:745
+#: modules/configuration.org:749
 #, no-wrap
 msgid ""
 "\"--sxl\" = {\n"
@@ -7567,13 +7572,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:774
+#: modules/configuration.org:778
 #, no-wrap
 msgid "Functions"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:776
+#: modules/configuration.org:780
 msgid ""
 "Helper functions used by the abbreviation system. These are separated from "
 "the abbreviation definitions because fish requires functions to be defined "
@@ -7581,13 +7586,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:780
+#: modules/configuration.org:784
 #, no-wrap
 msgid "fish-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:782
+#: modules/configuration.org:786
 #, no-wrap
 msgid ""
 "functions = {\n"
@@ -7599,19 +7604,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:789
+#: modules/configuration.org:793
 #, no-wrap
 msgid "Plugins"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:791
+#: modules/configuration.org:795
 #, no-wrap
 msgid "fish-plugins"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:793
+#: modules/configuration.org:797
 #, no-wrap
 msgid ""
 "plugins = [\n"
@@ -7627,7 +7632,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:805
+#: modules/configuration.org:809
 msgid ""
 "The [[https://github.com/franciscolourenco/done][done]] plugin provides "
 "desktop notifications for long-running commands.  The threshold is set to 15 "
@@ -7638,19 +7643,19 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:811
+#: modules/configuration.org:815
 #, no-wrap
 msgid "fish-done-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:814
+#: modules/configuration.org:818
 #, no-wrap
 msgid "set -U __done_min_cmd_duration 15000"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:817
+#: modules/configuration.org:821
 msgid ""
 "[[https://github.com/PatrickF1/fzf.fish][fzf-fish]] integrates fzf with "
 "fish's tab completion, history search, and file/directory navigation. It "
@@ -7659,13 +7664,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:821
+#: modules/configuration.org:825
 #, no-wrap
 msgid "Bash"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:823
+#: modules/configuration.org:827
 msgid ""
 "Bash is configured as a minimal fallback shell rather than a full "
 "interactive environment. The primary use case is ensuring a usable shell "
@@ -7676,7 +7681,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:836
+#: modules/configuration.org:840
 #, no-wrap
 msgid ""
 "{\n"
@@ -7692,25 +7697,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:847
+#: modules/configuration.org:851
 #, no-wrap
 msgid "<<bash-history>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:849
+#: modules/configuration.org:853
 #, no-wrap
 msgid "<<bash-completion>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:851
+#: modules/configuration.org:855
 #, no-wrap
 msgid "<<bash-aliases>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:853
+#: modules/configuration.org:857
 #, no-wrap
 msgid ""
 "    <<bash-init>>\n"
@@ -7719,13 +7724,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:858
+#: modules/configuration.org:862
 #, no-wrap
 msgid "History"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:860
+#: modules/configuration.org:864
 msgid ""
 "History is stored under =XDG_CONFIG_HOME= to keep =$HOME= clean, consistent "
 "with the repository's preference for XDG base directories (see [[*User-Level "
@@ -7733,25 +7738,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:863
+#: modules/configuration.org:867
 #, no-wrap
 msgid "bash-history"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:865
+#: modules/configuration.org:869
 #, no-wrap
 msgid "historyFile = \"$XDG_CONFIG_HOME/bash/history\";"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:868
+#: modules/configuration.org:872
 #, no-wrap
 msgid "Completion"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:870
+#: modules/configuration.org:874
 msgid ""
 "Bash completion is disabled because bash is not used as the primary "
 "interactive shell. Loading completion scripts adds startup time (~100ms+) "
@@ -7760,25 +7765,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:874
+#: modules/configuration.org:878
 #, no-wrap
 msgid "bash-completion"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:876
+#: modules/configuration.org:880
 #, no-wrap
 msgid "enableCompletion = false;"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:879
+#: modules/configuration.org:883
 #, no-wrap
 msgid "Aliases"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:881
+#: modules/configuration.org:885
 msgid ""
 "Basic aliases that provide a minimal quality-of-life improvement if bash is "
 "used interactively. These are intentionally simple — fish handles the rich "
@@ -7786,13 +7791,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:885
+#: modules/configuration.org:889
 #, no-wrap
 msgid "bash-aliases"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:887
+#: modules/configuration.org:891
 #, no-wrap
 msgid ""
 "shellAliases = {\n"
@@ -7804,13 +7809,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:895
+#: modules/configuration.org:899
 #, no-wrap
 msgid "Init"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:897
+#: modules/configuration.org:901
 msgid ""
 "This configuration is a remnant from before fish was set as the default "
 "login shell.  Previously, bash was the login shell and =.bashrc= launched "
@@ -7819,13 +7824,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:902
+#: modules/configuration.org:906
 #, no-wrap
 msgid "bash-init"
 msgstr ""
 
 #. type: plain list +
-#: modules/configuration.org:909
+#: modules/configuration.org:913
 #, no-wrap
 msgid ""
 "lib.optionalString (!config.programs.kitty.enable) ''\n"
@@ -7833,7 +7838,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:904
+#: modules/configuration.org:908
 #, no-wrap
 msgid ""
 "initExtra = ''\n"
@@ -7843,13 +7848,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:912
+#: modules/configuration.org:916
 #, no-wrap
 msgid "Terminal Settings"
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:918
+#: modules/configuration.org:922
 #, no-wrap
 msgid ""
 "=stty stop undef=: Disables =Ctrl+S= from sending =XOFF= (terminal pause), "
@@ -7862,7 +7867,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:921
+#: modules/configuration.org:925
 #, no-wrap
 msgid ""
 "=stty werase undef= + =bind \"\\C-w\":unix-filename-rubout=: Rebinds "
@@ -7873,13 +7878,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:922
+#: modules/configuration.org:926
 #, no-wrap
 msgid "bash-terminal-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:924
+#: modules/configuration.org:928
 #, no-wrap
 msgid ""
 "stty stop undef  # Ctrl-s\n"
@@ -7888,13 +7893,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:929
+#: modules/configuration.org:933
 #, no-wrap
 msgid "TMUX Auto-attach"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:931
+#: modules/configuration.org:935
 msgid ""
 "Automatically starts or attaches to a tmux session when bash is the "
 "interactive shell, but only when kitty is not the terminal emulator. Kitty "
@@ -7906,13 +7911,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:938
+#: modules/configuration.org:942
 #, no-wrap
 msgid "bash-tmux-autostart"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:941
+#: modules/configuration.org:945
 #, no-wrap
 msgid ""
 "if type tmux > /dev/null 2>&1; then\n"
@@ -7920,7 +7925,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:946
+#: modules/configuration.org:950
 #, no-wrap
 msgid ""
 "  while test -z $TMUX; do\n"
@@ -7930,13 +7935,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:952
+#: modules/configuration.org:956
 #, no-wrap
 msgid "Nushell"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:954
+#: modules/configuration.org:958
 msgid ""
 "Nushell is enabled for its ability to handle structured data natively, "
 "similar to PowerShell. Where traditional shells pipe text between commands, "
@@ -7947,7 +7952,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:961
+#: modules/configuration.org:965
 msgid ""
 "No custom configuration is added yet — the defaults are sufficient for "
 "exploratory use, and committing to Nushell-specific workflows would be "
@@ -7955,7 +7960,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:970
+#: modules/configuration.org:974
 #, no-wrap
 msgid ""
 "{ config, ... }:\n"
@@ -7967,13 +7972,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:978
+#: modules/configuration.org:982
 #, no-wrap
 msgid "Starship"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:980
+#: modules/configuration.org:984
 msgid ""
 "[[https://starship.rs/][Starship]] is a cross-shell prompt written in Rust, "
 "used across all shells configured here to provide a consistent prompt "
@@ -7983,14 +7988,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:984
+#: modules/configuration.org:988
 msgid ""
 "Starship does not natively support asynchronous prompt rendering, so this "
 "section also includes a custom async prompt module for fish."
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:993
+#: modules/configuration.org:997
 #, no-wrap
 msgid ""
 "{ pkgs, ... }:\n"
@@ -8004,13 +8009,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1008
+#: modules/configuration.org:1012
 #, no-wrap
 msgid "Prompt Format"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1010
+#: modules/configuration.org:1014
 msgid ""
 "The prompt format prepends a shell indicator before the default modules.  "
 "This makes it immediately visible which shell is active, useful when "
@@ -8018,32 +8023,32 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1015
+#: modules/configuration.org:1019
 #, no-wrap
 msgid "\"$schema\" = \"https://starship.rs/config-schema.json\""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1017
+#: modules/configuration.org:1021
 #, no-wrap
 msgid "format = \"$shell$all$line_break$character\""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1020
+#: modules/configuration.org:1024
 #, no-wrap
 msgid "Shell Indicator"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1022
+#: modules/configuration.org:1026
 msgid ""
 "Each shell has a distinct icon: =󰈺= (fish icon) for fish. Bash and nushell "
 "use the default indicator."
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1026
+#: modules/configuration.org:1030
 #, no-wrap
 msgid ""
 "[shell]\n"
@@ -8053,13 +8058,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1032
+#: modules/configuration.org:1036
 #, no-wrap
 msgid "Remote Container Detection"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1034
+#: modules/configuration.org:1038
 msgid ""
 "A custom module detects when running inside a VS Code Remote Container (Dev "
 "Container) by checking the =REMOTE_CONTAINERS= environment variable, "
@@ -8068,7 +8073,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1040
+#: modules/configuration.org:1044
 #, no-wrap
 msgid ""
 "[custom.remote-container]\n"
@@ -8078,13 +8083,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1046
+#: modules/configuration.org:1050
 #, no-wrap
 msgid "Disabled Modules"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1048
+#: modules/configuration.org:1052
 msgid ""
 "=gcloud= is disabled because it reads the active GCP configuration from the "
 "home directory (=~/.config/gcloud/=), causing it to appear in every "
@@ -8092,7 +8097,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1053
+#: modules/configuration.org:1057
 #, no-wrap
 msgid ""
 "[gcloud]\n"
@@ -8100,13 +8105,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1057
+#: modules/configuration.org:1061
 #, no-wrap
 msgid "Async Prompt Module"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1059
+#: modules/configuration.org:1063
 msgid ""
 "A custom home-manager module that replaces starship's default fish "
 "integration with an asynchronous variant. The async prompt script is "
@@ -8120,7 +8125,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1070
+#: modules/configuration.org:1074
 #, no-wrap
 msgid ""
 "{\n"
@@ -8151,7 +8156,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1097
+#: modules/configuration.org:1101
 #, no-wrap
 msgid ""
 "    programs.fish.interactiveShellInit = ''\n"
@@ -8166,13 +8171,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1107
+#: modules/configuration.org:1111
 #, no-wrap
 msgid "Async Prompt Script"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1116
+#: modules/configuration.org:1120
 #, no-wrap
 msgid ""
 "status is-interactive\n"
@@ -8180,7 +8185,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1119
+#: modules/configuration.org:1123
 #, no-wrap
 msgid ""
 "if test -n \"$XDG_RUNTIME_DIR\"\n"
@@ -8193,7 +8198,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1128
+#: modules/configuration.org:1132
 #, no-wrap
 msgid ""
 "set -g VIRTUAL_ENV_DISABLE_PROMPT 1\n"
@@ -8203,7 +8208,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1134
+#: modules/configuration.org:1138
 #, no-wrap
 msgid ""
 "function fish_prompt\n"
@@ -8217,7 +8222,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1144
+#: modules/configuration.org:1148
 #, no-wrap
 msgid ""
 "function __starship_async_fire --on-event fish_prompt\n"
@@ -8234,7 +8239,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1156
+#: modules/configuration.org:1160
 #, no-wrap
 msgid ""
 "    set -l tmpfile \"$__starship_async_tmpdir\"/\"$fish_pid\"_fish_prompt\n"
@@ -8249,7 +8254,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1163
+#: modules/configuration.org:1167
 #, no-wrap
 msgid ""
 "function __starship_async_simple_prompt\n"
@@ -8261,7 +8266,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1170
+#: modules/configuration.org:1174
 #, no-wrap
 msgid ""
 "function __starship_async_repaint_prompt --on-signal "
@@ -8271,7 +8276,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1174
+#: modules/configuration.org:1178
 #, no-wrap
 msgid ""
 "function __starship_async_cleanup --on-event fish_exit\n"
@@ -8280,19 +8285,19 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1182
+#: modules/configuration.org:1186
 #, no-wrap
 msgid "Version Control"
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1184
+#: modules/configuration.org:1188
 #, no-wrap
 msgid "Git"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1186
+#: modules/configuration.org:1190
 msgid ""
 "Git version control configuration. Git is configured directly through "
 "home-manager's =programs.git= module, which generates =~/.config/git/config= "
@@ -8300,7 +8305,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1195
+#: modules/configuration.org:1199
 #, no-wrap
 msgid ""
 "{ pkgs, config, ... }:\n"
@@ -8310,25 +8315,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1200
+#: modules/configuration.org:1204
 #, no-wrap
 msgid "<<git-settings>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1202
+#: modules/configuration.org:1206
 #, no-wrap
 msgid "<<git-signing>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1204
+#: modules/configuration.org:1208
 #, no-wrap
 msgid "<<git-ignores>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1206
+#: modules/configuration.org:1210
 #, no-wrap
 msgid ""
 "  <<git-scalar>>\n"
@@ -8336,31 +8341,31 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1209
+#: modules/configuration.org:1213
 #, no-wrap
 msgid "<<git-gh>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1211
+#: modules/configuration.org:1215
 #, no-wrap
 msgid "<<git-delta>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1213
+#: modules/configuration.org:1217
 #, no-wrap
 msgid "<<git-difftastic>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1215
+#: modules/configuration.org:1219
 #, no-wrap
 msgid "<<git-lazygit>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1217
+#: modules/configuration.org:1221
 #, no-wrap
 msgid ""
 "  <<git-fish-abbreviations>>\n"
@@ -8368,18 +8373,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1223
+#: modules/configuration.org:1227
 msgid "Basic git behavior settings."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1225
+#: modules/configuration.org:1229
 #, no-wrap
 msgid "git-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1227
+#: modules/configuration.org:1231
 #, no-wrap
 msgid ""
 "settings = {\n"
@@ -8393,19 +8398,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1237
+#: modules/configuration.org:1241
 #, no-wrap
 msgid "User Identity"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1239
+#: modules/configuration.org:1243
 #, no-wrap
 msgid "git-user-identity"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1241
+#: modules/configuration.org:1245
 #, no-wrap
 msgid ""
 "user = {\n"
@@ -8415,13 +8420,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1247 modules/configuration.org:1838
+#: modules/configuration.org:1251 modules/configuration.org:1842
 #, no-wrap
 msgid "Editor"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1249
+#: modules/configuration.org:1253
 msgid ""
 "=core.editor = \"vim\"= is set as the fallback editor for git "
 "operations. Although the =EDITOR= environment variable is set to =nvim= in "
@@ -8431,36 +8436,36 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1254
+#: modules/configuration.org:1258
 #, no-wrap
 msgid "git-editor"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1256
+#: modules/configuration.org:1260
 #, no-wrap
 msgid "core.editor = \"vim\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1259
+#: modules/configuration.org:1263
 #, no-wrap
 msgid "Color"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1261
+#: modules/configuration.org:1265
 msgid "Auto-detect terminal color support for all git subcommands."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1263
+#: modules/configuration.org:1267
 #, no-wrap
 msgid "git-color"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1265
+#: modules/configuration.org:1269
 #, no-wrap
 msgid ""
 "color = {\n"
@@ -8473,31 +8478,31 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1274
+#: modules/configuration.org:1278
 #, no-wrap
 msgid "Default Branch"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1276
+#: modules/configuration.org:1280
 #, no-wrap
 msgid "git-default-branch"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1278
+#: modules/configuration.org:1282
 #, no-wrap
 msgid "init.defaultBranch = \"main\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1281
+#: modules/configuration.org:1285
 #, no-wrap
 msgid "Force Push Safety"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1283
+#: modules/configuration.org:1287
 msgid ""
 "=push.useForceIfIncludes= enables a safety check for force pushes: git "
 "verifies that the local branch includes the remote's current tip before "
@@ -8508,25 +8513,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1289
+#: modules/configuration.org:1293
 #, no-wrap
 msgid "git-push-safety"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1291
+#: modules/configuration.org:1295
 #, no-wrap
 msgid "push.useForceIfIncludes = true;"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1294
+#: modules/configuration.org:1298
 #, no-wrap
 msgid "URL Rewriting"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1296
+#: modules/configuration.org:1300
 msgid ""
 "=url.\"git@github.com:\".pushInsteadOf= rewrites push URLs from HTTPS to "
 "SSH. This allows =git clone https://github.com/...= to work without SSH "
@@ -8535,7 +8540,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1301
+#: modules/configuration.org:1305
 msgid ""
 "In practice, [[*GitHub CLI][=gh=]] provides its own credential helper that "
 "handles HTTPS authentication transparently, so this rewrite rule may not be "
@@ -8544,25 +8549,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1305
+#: modules/configuration.org:1309
 #, no-wrap
 msgid "git-url-rewrite"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1307
+#: modules/configuration.org:1311
 #, no-wrap
 msgid "url.\"git@github.com:\".pushInsteadOf = \"https://github.com/\";"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1310
+#: modules/configuration.org:1314
 #, no-wrap
 msgid "Commit Signing"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1312
+#: modules/configuration.org:1316
 msgid ""
 "SSH-based commit signing. SSH keys were chosen over GPG because SSH keys are "
 "already required for push authentication, eliminating the need to manage a "
@@ -8572,7 +8577,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1317
+#: modules/configuration.org:1321
 msgid ""
 "GitHub has "
 "[[https://github.blog/changelog/2022-08-23-ssh-commit-verification-now-supported/][supported "
@@ -8585,7 +8590,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1322
+#: modules/configuration.org:1326
 msgid ""
 "In the future, migrating to a keyless solution like "
 "[[https://github.com/sigstore/gitsign][gitsign]] (Sigstore-based signing)  "
@@ -8594,20 +8599,20 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1326
+#: modules/configuration.org:1330
 msgid ""
 "=signByDefault = true= ensures all commits are signed without requiring =git "
 "commit -S=, preventing unsigned commits from slipping through."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1329
+#: modules/configuration.org:1333
 #, no-wrap
 msgid "git-signing"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1331
+#: modules/configuration.org:1335
 #, no-wrap
 msgid ""
 "signing = {\n"
@@ -8618,13 +8623,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1338
+#: modules/configuration.org:1342
 #, no-wrap
 msgid "Global Ignores"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1340
+#: modules/configuration.org:1344
 msgid ""
 "Patterns that should never be committed across all repositories. These are "
 "global ignores rather than per-repo =.gitignore= entries because they "
@@ -8633,13 +8638,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1344
+#: modules/configuration.org:1348
 #, no-wrap
 msgid "git-ignores"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1346
+#: modules/configuration.org:1350
 #, no-wrap
 msgid ""
 "ignores = [\n"
@@ -8651,43 +8656,43 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1354
+#: modules/configuration.org:1358
 #, no-wrap
 msgid "OS Artifacts"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1356
+#: modules/configuration.org:1360
 msgid ""
 "macOS Finder metadata files. Present in the global ignore because this is a "
 "cross-platform dotfiles repository used on both Linux and macOS."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1359
+#: modules/configuration.org:1363
 #, no-wrap
 msgid "git-ignores-os"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1361
+#: modules/configuration.org:1365
 #, no-wrap
 msgid "\".DS_Store\""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1364
+#: modules/configuration.org:1368
 #, no-wrap
 msgid "Development Environment"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1366
+#: modules/configuration.org:1370
 msgid "Artifacts generated by development tools that should remain local:"
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1370
+#: modules/configuration.org:1374
 #, no-wrap
 msgid ""
 "=.aider*= matches aider's conversation history and configuration "
@@ -8696,7 +8701,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1373
+#: modules/configuration.org:1377
 #, no-wrap
 msgid ""
 "=.direnv=, =.envrc=: direnv state and configuration. Each project may define "
@@ -8707,13 +8712,13 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1374
+#: modules/configuration.org:1378
 #, no-wrap
 msgid "=.ipynb_checkpoints=: Jupyter Notebook autosave files."
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1376
+#: modules/configuration.org:1380
 #, no-wrap
 msgid ""
 "=.pre-commit-config.yaml=: Managed per-project by devshell environments "
@@ -8722,25 +8727,25 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1377
+#: modules/configuration.org:1381
 #, no-wrap
 msgid "=.vscode/=: Editor-specific settings that vary per developer."
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1378
+#: modules/configuration.org:1382
 #, no-wrap
 msgid "=__pycache__/=: Python bytecode cache, regenerated on each run."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1379
+#: modules/configuration.org:1383
 #, no-wrap
 msgid "git-ignores-dev"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1381
+#: modules/configuration.org:1385
 #, no-wrap
 msgid ""
 "\".aider*\"\n"
@@ -8753,62 +8758,62 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1390
+#: modules/configuration.org:1394
 #, no-wrap
 msgid "Workflow"
 msgstr ""
 
 #. type: plain list -
-#: modules/configuration.org:1393
+#: modules/configuration.org:1397
 #, no-wrap
 msgid "=.worktree=: Marker file used by git worktree workflows."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1394
+#: modules/configuration.org:1398
 #, no-wrap
 msgid "git-ignores-workflow"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1396
+#: modules/configuration.org:1400
 #, no-wrap
 msgid "\".worktree\""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1399
+#: modules/configuration.org:1403
 #, no-wrap
 msgid "Private Notes"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1401
+#: modules/configuration.org:1405
 msgid ""
 "=.private/= is a directory for personal notes, LLM context files, and other "
 "local-only documentation that should never be shared."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1404
+#: modules/configuration.org:1408
 #, no-wrap
 msgid "git-ignores-private"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1406
+#: modules/configuration.org:1410
 #, no-wrap
 msgid "\".private/\""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1409
+#: modules/configuration.org:1413
 #, no-wrap
 msgid "Scalar"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1411
+#: modules/configuration.org:1415
 msgid ""
 "[[https://git-scm.com/docs/scalar][Scalar]] optimizes git performance for "
 "large repositories. Enabled specifically for the nixpkgs repository, which "
@@ -8818,7 +8823,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1416
+#: modules/configuration.org:1420
 msgid ""
 "The Scalar module (=programs.git.scalar=) is a custom home-manager module "
 "defined in [[file:home-manager/git-scalar.nix][home-manager/git-scalar.nix]] "
@@ -8827,13 +8832,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1420
+#: modules/configuration.org:1424
 #, no-wrap
 msgid "git-scalar"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1422
+#: modules/configuration.org:1426
 #, no-wrap
 msgid ""
 "scalar = {\n"
@@ -8845,13 +8850,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1428
+#: modules/configuration.org:1432
 #, no-wrap
 msgid "GitHub CLI"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1430
+#: modules/configuration.org:1434
 msgid ""
 "[[https://cli.github.com/][gh]] (GitHub CLI) is enabled alongside git "
 "because it provides a credential helper "
@@ -8863,25 +8868,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1436
+#: modules/configuration.org:1440
 #, no-wrap
 msgid "git-gh"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1438
+#: modules/configuration.org:1442
 #, no-wrap
 msgid "programs.gh.enable = true;"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1441
+#: modules/configuration.org:1445
 #, no-wrap
 msgid "Delta"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1443
+#: modules/configuration.org:1447
 msgid ""
 "[[https://github.com/dandavison/delta][delta]] provides syntax-highlighted "
 "diffs in the terminal with line numbers and side-by-side view "
@@ -8889,13 +8894,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1446
+#: modules/configuration.org:1450
 #, no-wrap
 msgid "git-delta"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1448
+#: modules/configuration.org:1452
 #, no-wrap
 msgid ""
 "programs.delta = {\n"
@@ -8905,13 +8910,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1454
+#: modules/configuration.org:1458
 #, no-wrap
 msgid "Difftastic"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1456
+#: modules/configuration.org:1460
 msgid ""
 "[[https://github.com/Wilfred/difftastic][Difftastic]] is a structural diff "
 "tool that operates at the AST level rather than comparing lines. It "
@@ -8923,7 +8928,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1462
+#: modules/configuration.org:1466
 msgid ""
 "Both difftastic and [[*Delta][delta]] are kept because they serve "
 "complementary roles: delta enhances git's built-in line diffs with syntax "
@@ -8933,13 +8938,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1467
+#: modules/configuration.org:1471
 #, no-wrap
 msgid "git-difftastic"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1469
+#: modules/configuration.org:1473
 #, no-wrap
 msgid ""
 "programs.difftastic = {\n"
@@ -8948,13 +8953,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1474
+#: modules/configuration.org:1478
 #, no-wrap
 msgid "Lazygit"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1476
+#: modules/configuration.org:1480
 msgid ""
 "[[https://github.com/jesseduffield/lazygit][Lazygit]] is a terminal UI for "
 "git. A TUI was chosen over raw git commands for interactive operations like "
@@ -8966,7 +8971,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1482
+#: modules/configuration.org:1486
 msgid ""
 "Performance degrades noticeably on large repositories like nixpkgs, but the "
 "ergonomics and active development make it a trusted part of the workflow "
@@ -8974,13 +8979,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1485
+#: modules/configuration.org:1489
 #, no-wrap
 msgid "git-lazygit"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1487
+#: modules/configuration.org:1491
 #, no-wrap
 msgid ""
 "programs.lazygit = {\n"
@@ -8990,7 +8995,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1492
+#: modules/configuration.org:1496
 #, no-wrap
 msgid ""
 "    <<lazygit-git>>\n"
@@ -8999,24 +9004,24 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1497
+#: modules/configuration.org:1501
 #, no-wrap
 msgid "GUI"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1499
+#: modules/configuration.org:1503
 msgid "Enable Nerd Font icons in the lazygit interface for visual clarity."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1501
+#: modules/configuration.org:1505
 #, no-wrap
 msgid "lazygit-gui"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1503
+#: modules/configuration.org:1507
 #, no-wrap
 msgid ""
 "gui = {\n"
@@ -9025,13 +9030,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1508
+#: modules/configuration.org:1512
 #, no-wrap
 msgid "Git Integration"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1510
+#: modules/configuration.org:1514
 msgid ""
 "=overrideGpg = true= tells lazygit to run git commands inline instead of "
 "spawning a subprocess for GPG/SSH signing. By default, lazygit defers to a "
@@ -9046,7 +9051,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1519
+#: modules/configuration.org:1523
 msgid ""
 "The pager configuration integrates both [[*Delta][delta]] and "
 "[[*Difftastic][difftastic]] into lazygit's diff views.  Delta provides "
@@ -9056,13 +9061,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1524
+#: modules/configuration.org:1528
 #, no-wrap
 msgid "lazygit-git"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1526
+#: modules/configuration.org:1530
 #, no-wrap
 msgid ""
 "git = {\n"
@@ -9080,13 +9085,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1540
+#: modules/configuration.org:1544
 #, no-wrap
 msgid "Fish Abbreviations"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1542
+#: modules/configuration.org:1546
 msgid ""
 "Shell abbreviations for frequent git operations. Abbreviations (not aliases) "
 "are used because fish expands them inline before execution, making the "
@@ -9094,13 +9099,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1546
+#: modules/configuration.org:1550
 #, no-wrap
 msgid "git-fish-abbreviations"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1548
+#: modules/configuration.org:1552
 #, no-wrap
 msgid ""
 "programs.fish.shellAbbrs = {\n"
@@ -9114,38 +9119,38 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1558
+#: modules/configuration.org:1562
 #, no-wrap
 msgid "Push"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1560
+#: modules/configuration.org:1564
 msgid ""
 "Force push with lease — safer than =--force= as it prevents overwriting "
 "remote changes not yet fetched."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1563
+#: modules/configuration.org:1567
 #, no-wrap
 msgid "git-abbr-push"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1565
+#: modules/configuration.org:1569
 #, no-wrap
 msgid "gpf = \"git push --force-with-lease\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1568
+#: modules/configuration.org:1572
 #, no-wrap
 msgid "Pull"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1570
+#: modules/configuration.org:1574
 msgid ""
 "=gpm= pulls from the remote's default branch, dynamically detected via =git "
 "remote show= rather than hardcoding =main= or =master=. This handles "
@@ -9153,20 +9158,20 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1574
+#: modules/configuration.org:1578
 msgid ""
 "=gpu= pulls from upstream — used in fork workflows to sync with the original "
 "repository."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1576
+#: modules/configuration.org:1580
 #, no-wrap
 msgid "git-abbr-pull"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1578
+#: modules/configuration.org:1582
 #, no-wrap
 msgid ""
 "gpm = \"git pull (git remote show origin | sed -n '/HEAD branch/s/.*: "
@@ -9175,33 +9180,33 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1582
+#: modules/configuration.org:1586
 #, no-wrap
 msgid "Commit"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1584
+#: modules/configuration.org:1588
 msgid ""
 "=gci= creates a commit. The trailing space allows directly appending =-m "
 "\"message\"=."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1586
+#: modules/configuration.org:1590
 msgid ""
 "=gca= amends the last commit, frequently used during interactive rebase "
 "workflows."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1588
+#: modules/configuration.org:1592
 #, no-wrap
 msgid "git-abbr-commit"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1590
+#: modules/configuration.org:1594
 #, no-wrap
 msgid ""
 "gci = \"git commit \";\n"
@@ -9209,37 +9214,37 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1594
+#: modules/configuration.org:1598
 #, no-wrap
 msgid "Status"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1596
+#: modules/configuration.org:1600
 #, no-wrap
 msgid "git-abbr-status"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1598
+#: modules/configuration.org:1602
 #, no-wrap
 msgid "gs = \"git status\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1601
+#: modules/configuration.org:1605
 #, no-wrap
 msgid "Stash"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1603
+#: modules/configuration.org:1607
 #, no-wrap
 msgid "git-abbr-stash"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1605
+#: modules/configuration.org:1609
 #, no-wrap
 msgid ""
 "gst = \"git stash\";\n"
@@ -9247,19 +9252,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1609
+#: modules/configuration.org:1613
 #, no-wrap
 msgid "Switch"
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1611
+#: modules/configuration.org:1615
 #, no-wrap
 msgid "git-abbr-switch"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1613
+#: modules/configuration.org:1617
 #, no-wrap
 msgid ""
 "gsw = \"git switch\";\n"
@@ -9267,19 +9272,19 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1617
+#: modules/configuration.org:1621
 #, no-wrap
 msgid "Browser"
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1619
+#: modules/configuration.org:1623
 #, no-wrap
 msgid "Zen Browser"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1621
+#: modules/configuration.org:1625
 msgid ""
 "[[https://zen-browser.app/][Zen Browser]] is a Firefox-based browser with a "
 "focus on privacy and customization.  Firefox derivatives were preferred over "
@@ -9290,7 +9295,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1626
+#: modules/configuration.org:1630
 msgid ""
 "Zen Browser was chosen over vanilla Firefox for its improved UI/UX while "
 "retaining full Firefox compatibility — extensions, search engines, and "
@@ -9298,7 +9303,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1635
+#: modules/configuration.org:1639
 #, no-wrap
 msgid ""
 "{\n"
@@ -9316,7 +9321,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1648
+#: modules/configuration.org:1652
 #, no-wrap
 msgid ""
 "options.my.programs.zen-browser = {\n"
@@ -9325,7 +9330,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1652
+#: modules/configuration.org:1656
 #, no-wrap
 msgid ""
 "config = lib.mkIf cfg.enable {\n"
@@ -9336,13 +9341,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1658
+#: modules/configuration.org:1662
 #, no-wrap
 msgid "<<zen-browser-search>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1660
+#: modules/configuration.org:1664
 #, no-wrap
 msgid ""
 "        <<zen-browser-extensions>>\n"
@@ -9353,13 +9358,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1667
+#: modules/configuration.org:1671
 #, no-wrap
 msgid "Settings"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1669
+#: modules/configuration.org:1673
 msgid ""
 "Auto-install extensions without user prompts. By default, Firefox shows a "
 "confirmation dialog for each extension installed via the profile. Setting "
@@ -9370,13 +9375,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1675
+#: modules/configuration.org:1679
 #, no-wrap
 msgid "zen-browser-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1677
+#: modules/configuration.org:1681
 #, no-wrap
 msgid ""
 "settings = {\n"
@@ -9385,13 +9390,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1682
+#: modules/configuration.org:1686
 #, no-wrap
 msgid "Search Engines"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1684
+#: modules/configuration.org:1688
 msgid ""
 "Custom search engines for quick access to development-related package "
 "registries and documentation. Each engine is assigned a short alias (e.g., "
@@ -9400,13 +9405,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1688
+#: modules/configuration.org:1692
 #, no-wrap
 msgid "zen-browser-search"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1690
+#: modules/configuration.org:1694
 #, no-wrap
 msgid ""
 "search = {\n"
@@ -9416,31 +9421,31 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1695
+#: modules/configuration.org:1699
 #, no-wrap
 msgid "<<zen-browser-search-engine-nixos-wiki>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1697
+#: modules/configuration.org:1701
 #, no-wrap
 msgid "<<zen-browser-search-engine-noogle>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1699
+#: modules/configuration.org:1703
 #, no-wrap
 msgid "<<zen-browser-search-engine-crates-io>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1701
+#: modules/configuration.org:1705
 #, no-wrap
 msgid "<<zen-browser-search-engine-npm>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1703
+#: modules/configuration.org:1707
 #, no-wrap
 msgid ""
 "    <<zen-browser-search-engine-pypi>>\n"
@@ -9449,13 +9454,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1708
+#: modules/configuration.org:1712
 #, no-wrap
 msgid "Nix Packages"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1710
+#: modules/configuration.org:1714
 msgid ""
 "Search the official NixOS/nixpkgs repository. Uses =nixos-icons= from "
 "nixpkgs for the icon to avoid depending on an external URL that could change "
@@ -9463,13 +9468,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1713
+#: modules/configuration.org:1717
 #, no-wrap
 msgid "zen-browser-search-engine-nix-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1715
+#: modules/configuration.org:1719
 #, no-wrap
 msgid ""
 "nix-packages = {\n"
@@ -9492,7 +9497,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1733
+#: modules/configuration.org:1737
 #, no-wrap
 msgid ""
 "  icon = "
@@ -9502,26 +9507,26 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1738
+#: modules/configuration.org:1742
 #, no-wrap
 msgid "NixOS Wiki"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1740
+#: modules/configuration.org:1744
 msgid ""
 "Search the NixOS community wiki for configuration examples and "
 "troubleshooting guides."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1742
+#: modules/configuration.org:1746
 #, no-wrap
 msgid "zen-browser-search-engine-nixos-wiki"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1744
+#: modules/configuration.org:1748
 #, no-wrap
 msgid ""
 "nixos-wiki = {\n"
@@ -9534,13 +9539,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1752
+#: modules/configuration.org:1756
 #, no-wrap
 msgid "noogle"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1754
+#: modules/configuration.org:1758
 msgid ""
 "[[https://noogle.dev/][noogle]] is a Nix function search engine — the "
 "equivalent of Hoogle for Haskell.  Useful for discovering library functions "
@@ -9548,13 +9553,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1757
+#: modules/configuration.org:1761
 #, no-wrap
 msgid "zen-browser-search-engine-noogle"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1759
+#: modules/configuration.org:1763
 #, no-wrap
 msgid ""
 "noogle = {\n"
@@ -9566,26 +9571,26 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1767
+#: modules/configuration.org:1771
 #, no-wrap
 msgid "crates.io"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1769
+#: modules/configuration.org:1773
 msgid ""
 "Search the Rust package registry for crate discovery and version "
 "information."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1771
+#: modules/configuration.org:1775
 #, no-wrap
 msgid "zen-browser-search-engine-crates-io"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1773
+#: modules/configuration.org:1777
 #, no-wrap
 msgid ""
 "crates-io = {\n"
@@ -9597,24 +9602,24 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1781
+#: modules/configuration.org:1785
 #, no-wrap
 msgid "npm"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1783
+#: modules/configuration.org:1787
 msgid "Search the npm registry for JavaScript/TypeScript package discovery."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1785
+#: modules/configuration.org:1789
 #, no-wrap
 msgid "zen-browser-search-engine-npm"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1787
+#: modules/configuration.org:1791
 #, no-wrap
 msgid ""
 "npm = {\n"
@@ -9627,24 +9632,24 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1795
+#: modules/configuration.org:1799
 #, no-wrap
 msgid "PyPI"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1797
+#: modules/configuration.org:1801
 msgid "Search the Python Package Index for Python package discovery."
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1799
+#: modules/configuration.org:1803
 #, no-wrap
 msgid "zen-browser-search-engine-pypi"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1801
+#: modules/configuration.org:1805
 #, no-wrap
 msgid ""
 "pypi = {\n"
@@ -9656,13 +9661,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1809
+#: modules/configuration.org:1813
 #, no-wrap
 msgid "Extensions"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1811
+#: modules/configuration.org:1815
 msgid ""
 "Browser extensions managed declaratively. Extensions are sourced from two "
 "overlay-provided sets: =firefox-addons= (from the NUR firefox-addons "
@@ -9671,13 +9676,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:1815
+#: modules/configuration.org:1819
 #, no-wrap
 msgid "zen-browser-extensions"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1817
+#: modules/configuration.org:1821
 #, no-wrap
 msgid ""
 "extensions = {\n"
@@ -9702,20 +9707,20 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1840
+#: modules/configuration.org:1844
 #, no-wrap
 msgid "Neovim"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1842
+#: modules/configuration.org:1846
 msgid ""
 "Neovim is the editor I spend the most time in, primarily for coding — though "
 "the gravitational pull of =org-mode= is slowly dragging me over to Emacs."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1846
+#: modules/configuration.org:1850
 msgid ""
 "Everything Neovim-related lives under =flake/features/neovim/=: the wrapped "
 "derivation (=package.nix=) and the lua configuration. The flake-parts module "
@@ -9723,7 +9728,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 1.
-#: modules/configuration.org:1852
+#: modules/configuration.org:1856
 #, no-wrap
 msgid ""
 "=perSystem.packages.neovim= makes =nix run .#neovim= work on every\n"
@@ -9731,7 +9736,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 2.
-#: modules/configuration.org:1855
+#: modules/configuration.org:1859
 #, no-wrap
 msgid ""
 "=flake.homeManagerModules.neovim= lets a home-manager config opt in\n"
@@ -9740,7 +9745,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1857
+#: modules/configuration.org:1861
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -9757,7 +9762,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1869
+#: modules/configuration.org:1873
 #, no-wrap
 msgid ""
 "  config = lib.mkIf config.my.programs.neovim.enable {\n"
@@ -9771,7 +9776,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1878
+#: modules/configuration.org:1882
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -9783,13 +9788,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1886
+#: modules/configuration.org:1890
 #, no-wrap
 msgid "Emacs"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1888
+#: modules/configuration.org:1892
 msgid ""
 "Emacs has been my second-most-used editor since early 2026. The draw is "
 "=org-mode= — the workflows built around =org-capture= and =org-agenda= are "
@@ -9799,14 +9804,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1894
+#: modules/configuration.org:1898
 msgid ""
 "The feature lives alongside Neovim under =flake/features/emacs/= and pulls "
 "the same double duty:"
 msgstr ""
 
 #. type: plain list 1.
-#: modules/configuration.org:1901
+#: modules/configuration.org:1905
 #, no-wrap
 msgid ""
 "=perSystem.packages.emacs= exposes a wrapped emacs as a flake\n"
@@ -9816,7 +9821,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 2.
-#: modules/configuration.org:1905
+#: modules/configuration.org:1909
 #, no-wrap
 msgid ""
 "=flake.homeManagerModules.emacs= adds =my.programs.emacs.enable= for\n"
@@ -9826,7 +9831,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1908
+#: modules/configuration.org:1912
 #, no-wrap
 msgid ""
 "{ lib, inputs, ... }:\n"
@@ -9836,7 +9841,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1912
+#: modules/configuration.org:1916
 #, no-wrap
 msgid ""
 "emacsUnwrapped =\n"
@@ -9849,7 +9854,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1922
+#: modules/configuration.org:1926
 #, no-wrap
 msgid ""
 "tangle =\n"
@@ -9870,7 +9875,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1937
+#: modules/configuration.org:1941
 #, no-wrap
 msgid ""
 "tangleEl =\n"
@@ -9885,7 +9890,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1947
+#: modules/configuration.org:1951
 #, no-wrap
 msgid ""
 "  mkEmacs =\n"
@@ -9911,7 +9916,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1968
+#: modules/configuration.org:1972
 #, no-wrap
 msgid ""
 "config = lib.mkIf config.my.programs.emacs.enable {\n"
@@ -9922,7 +9927,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1974
+#: modules/configuration.org:1978
 #, no-wrap
 msgid ""
 "services.emacs = {\n"
@@ -9932,7 +9937,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1979
+#: modules/configuration.org:1983
 #, no-wrap
 msgid ""
 "xdg.configFile.\"emacs/init.el\".source = tangleEl pkgs ./init.org;\n"
@@ -9942,7 +9947,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1983
+#: modules/configuration.org:1987
 #, no-wrap
 msgid ""
 "    home.shellAliases = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin "
@@ -9955,7 +9960,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1989
+#: modules/configuration.org:1993
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -9967,7 +9972,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1998
+#: modules/configuration.org:2002
 #, no-wrap
 msgid ""
 "{\n"
@@ -10026,25 +10031,25 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:2054
+#: modules/configuration.org:2058
 #, no-wrap
 msgid "early-init.org"
 msgstr ""
 
 #. type: keyword INCLUDE
-#: modules/configuration.org:2055
+#: modules/configuration.org:2059
 #, no-wrap
 msgid "\"./flake/features/emacs/early-init.org\""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:2056
+#: modules/configuration.org:2060
 #, no-wrap
 msgid "init.org"
 msgstr ""
 
 #. type: keyword INCLUDE
-#: modules/configuration.org:2057
+#: modules/configuration.org:2061
 #, no-wrap
 msgid "\"./flake/features/emacs/init.org\""
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-05-28 00:51+0900\n"
+"POT-Creation-Date: 2026-05-30 18:42+0900\n"
 "PO-Revision-Date: 2026-03-01 14:13+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -434,8 +434,8 @@ msgstr ""
 
 #. type: heading ***
 #: configuration.org:71 modules/flake/features/emacs/init.org:607
-#: modules/configuration.org:71 modules/configuration.org:321
-#: modules/configuration.org:514
+#: modules/configuration.org:71 modules/configuration.org:325
+#: modules/configuration.org:518
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
@@ -1905,7 +1905,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "extra-substituters = [\n"
-"  \"https://natsukium.cachix.org\"\n"
+"  \"https://cache.natsukium.com/dotfiles\"\n"
 "  \"https://nix-community.cachix.org\"\n"
 "];"
 msgstr ""
@@ -1915,7 +1915,7 @@ msgstr ""
 #, no-wrap
 msgid ""
 "extra-trusted-public-keys = [\n"
-"  \"natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI=\"\n"
+"  \"dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols=\"\n"
 "  \"nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=\"\n"
 "];"
 msgstr ""
@@ -1963,13 +1963,18 @@ msgstr ""
 #. type: heading *****
 #: configuration.org:866
 #, no-wrap
-msgid "natsukium.cachix.org"
-msgstr "natsukium.cachix.org"
+msgid "cache.natsukium.com"
+msgstr "cache.natsukium.com"
 
 #. type: paragraph
 #: configuration.org:868
+#, fuzzy
+#| msgid ""
+#| "Personal binary cache containing outputs from this flake. Packages not "
+#| "available in the official =cache.nixos.org= or =nix-community.cachix.org= "
+#| "are built on GitHub Actions and pushed here."
 msgid ""
-"Personal binary cache containing outputs from this flake. Packages not "
+"Self-hosted Attic cache containing outputs from this flake. Packages not "
 "available in the official =cache.nixos.org= or =nix-community.cachix.org= "
 "are built on GitHub Actions and pushed here."
 msgstr ""
@@ -6525,7 +6530,7 @@ msgstr ""
 "darwinで共有され、すべてのマシンで一貫したNixの動作を提供します。"
 
 #. type: heading ***
-#: modules/configuration.org:20 modules/configuration.org:1221
+#: modules/configuration.org:20 modules/configuration.org:1225
 #, no-wrap
 msgid "Core Settings"
 msgstr "コア設定"
@@ -6573,7 +6578,7 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:55 modules/configuration.org:473
+#: modules/configuration.org:55 modules/configuration.org:477
 #, no-wrap
 msgid "Options"
 msgstr "オプション"
@@ -6829,40 +6834,60 @@ msgstr ""
 
 #. type: paragraph
 #: modules/configuration.org:163
+#, fuzzy
+#| msgid ""
+#| "Three binary caches are configured. =cache.natsukium.com= is a self-"
+#| "hosted Attic instance (running on serengeti, backed by Cloudflare R2) "
+#| "that CI pushes this flake's pre-built artifacts to. It took over from "
+#| "=natsukium.cachix.org= because the dotfiles closures outgrew Cachix's "
+#| "storage limits; Cachix is still used for other projects, but "
+#| "=natsukium.cachix.org= is kept here only as a substituter so paths built "
+#| "before the switch still resolve. =nix-community= provides caches for "
+#| "community projects including NVIDIA/CUDA packages and other nix-community-"
+#| "maintained derivations."
 msgid ""
-"Two binary caches are configured: =natsukium= holds pre-built artifacts for "
-"this dotfiles repository (CI-built system closures and custom packages), and "
-"=nix-community= provides caches for community projects including NVIDIA/CUDA "
-"packages and other nix-community-maintained derivations."
+"Three binary caches are configured. =cache.natsukium.com= is a self-hosted "
+"Attic instance (running on serengeti, backed by Cloudflare R2) that CI "
+"pushes this flake's pre-built artifacts to. It took over from "
+"=natsukium.cachix.org= because the dotfiles closures outgrew Cachix's "
+"storage limits.  =nix-community= provides caches for community projects "
+"including NVIDIA/CUDA packages and other nix-community-maintained "
+"derivations."
 msgstr ""
-"2つのバイナリキャッシュが設定されています。=natsukium= はこのdotfilesリポジト"
-"リのビルド済みアーティファクト（CIでビルドされたシステムクロージャーやカスタ"
-"ムパッケージ）を保持し、=nix-community= はNVIDIA/CUDAパッケージやその他のnix-"
-"communityが管理するderivationを含むコミュニティプロジェクトのキャッシュを提供"
-"します。"
+"3つのバイナリキャッシュが設定されています。=cache.natsukium.com= は "
+"serengeti 上で動作する自前ホストの Attic インスタンス（ストレージは "
+"Cloudflare R2）で、CI はこのフレークのビルド済み成果物をここに push します。"
+"dotfiles のクロージャが Cachix のストレージ上限に収まらなくなったため "
+"=natsukium.cachix.org= から移行したものです。Cachix は他のプロジェクトで引き"
+"続き使用していますが、=natsukium.cachix.org= は切り替え前にビルドされたパスを"
+"引き続き解決できるよう substituter としてのみ残しています。=nix-community= "
+"は NVIDIA/CUDA パッケージをはじめとする nix-community がメンテナンスする派生"
+"物など、コミュニティプロジェクト向けのキャッシュを提供します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:168
+#: modules/configuration.org:170
 #, no-wrap
 msgid "nix-substituters"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:170
+#: modules/configuration.org:172
 #, no-wrap
 msgid ""
 "nix.settings = {\n"
 "  substituters = [\n"
+"    \"https://cache.natsukium.com/dotfiles\"\n"
 "    \"https://natsukium.cachix.org\"\n"
 "    \"https://nix-community.cachix.org\"\n"
 "  ];"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:176
+#: modules/configuration.org:179
 #, no-wrap
 msgid ""
 "  trusted-public-keys = [\n"
+"    \"dotfiles:ubfx5NMqcrhL5eAouZ/qYiuDFj1VHCHWY0eaBFCdols=\"\n"
 "    \"natsukium.cachix.org-1:STD7ru7/5+KJX21m2yuDlgV6PnZP/v5VZWAJ8DZdMlI=\"\n"
 "    \"nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=\"\n"
 "  ];\n"
@@ -6870,13 +6895,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:183
+#: modules/configuration.org:187
 #, no-wrap
 msgid "Sandbox"
 msgstr "サンドボックス"
 
 #. type: paragraph
-#: modules/configuration.org:185
+#: modules/configuration.org:189
 msgid ""
 "The sandbox is set to =\"relaxed\"= on Darwin to avoid unexpected build "
 "failures. With =sandbox = true=, some packages fail to build on macOS due to "
@@ -6899,25 +6924,25 @@ msgstr ""
 "れらの失敗を防ぎます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:194
+#: modules/configuration.org:198
 #, no-wrap
 msgid "nix-sandbox"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:196
+#: modules/configuration.org:200
 #, no-wrap
 msgid "nix.settings.sandbox = if pkgs.stdenv.hostPlatform.isDarwin then \"relaxed\" else true;"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:199
+#: modules/configuration.org:203
 #, no-wrap
 msgid "Trusted Users"
 msgstr "信頼されたユーザー"
 
 #. type: paragraph
-#: modules/configuration.org:201
+#: modules/configuration.org:205
 msgid ""
 "On macOS, administrative users belong to the =admin= group, not =wheel= "
 "(which only contains =root=). Without =@admin=, the primary user would not "
@@ -6928,13 +6953,13 @@ msgstr ""
 "リユーザーがNixデーモンから信頼されません。"
 
 #. type: keyword NAME
-#: modules/configuration.org:205
+#: modules/configuration.org:209
 #, no-wrap
 msgid "nix-trusted-users"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:207
+#: modules/configuration.org:211
 #, no-wrap
 msgid ""
 "nix.settings.trusted-users = [\n"
@@ -6945,13 +6970,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:214
+#: modules/configuration.org:218
 #, no-wrap
 msgid "Extra Options"
 msgstr "追加オプション"
 
 #. type: paragraph
-#: modules/configuration.org:216
+#: modules/configuration.org:220
 msgid ""
 "Terminates builds that produce no output for 3600 seconds (1 hour). Some "
 "heavy builds (e.g., Chromium, kernel compilation, CUDA-based deep learning "
@@ -6965,13 +6990,13 @@ msgstr ""
 "にタイムアウトは余裕を持って設定されています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:221
+#: modules/configuration.org:225
 #, no-wrap
 msgid "nix-extra-options"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:223
+#: modules/configuration.org:227
 #, no-wrap
 msgid ""
 "nix.extraOptions = ''\n"
@@ -6980,13 +7005,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:228
+#: modules/configuration.org:232
 #, no-wrap
 msgid "Nixpkgs"
 msgstr "Nixpkgs"
 
 #. type: paragraph
-#: modules/configuration.org:230
+#: modules/configuration.org:234
 msgid ""
 "Nixpkgs configuration. =allowUnfree= is enabled by default. While free "
 "software is preferred where possible, strictly enforcing it is impractical — "
@@ -7001,7 +7026,7 @@ msgstr ""
 "な依存関係の数を考えると過度に煩雑です。"
 
 #. type: paragraph in src
-#: modules/configuration.org:242
+#: modules/configuration.org:246
 #, no-wrap
 msgid ""
 "{ config, lib, ... }:\n"
@@ -7020,7 +7045,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:256
+#: modules/configuration.org:260
 #, no-wrap
 msgid ""
 "  allowUnfree = mkOption {\n"
@@ -7033,7 +7058,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:264
+#: modules/configuration.org:268
 #, no-wrap
 msgid ""
 "  config = mkIf cfg.enable {\n"
@@ -7045,13 +7070,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:272
+#: modules/configuration.org:276
 #, no-wrap
 msgid "Distributed Builds"
 msgstr "分散ビルド"
 
 #. type: paragraph
-#: modules/configuration.org:274
+#: modules/configuration.org:278
 msgid ""
 "[[https://nix.dev/manual/nix/latest/advanced-topics/distributed-builds]"
 "[Distributed build]] configuration using Nix's built-in =buildMachines= "
@@ -7065,7 +7090,7 @@ msgstr ""
 "derivationのビルド時間を大幅に短縮します。"
 
 #. type: paragraph
-#: modules/configuration.org:278
+#: modules/configuration.org:282
 msgid ""
 "=nix.distributedBuilds= is set to =mkDefault true= here so that server "
 "profiles can override it to =false=. =nix.buildMachines= is harmless when "
@@ -7084,7 +7109,7 @@ msgstr ""
 "オーバーヘッドや循環依存が生じるためです。"
 
 #. type: paragraph in src
-#: modules/configuration.org:291
+#: modules/configuration.org:295
 #, no-wrap
 msgid ""
 "{\n"
@@ -7101,7 +7126,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:303
+#: modules/configuration.org:307
 #, no-wrap
 msgid ""
 "  <<build-machines-known-hosts>>\n"
@@ -7109,13 +7134,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:307
+#: modules/configuration.org:311
 #, no-wrap
 msgid "Protocol Selection"
 msgstr "プロトコルの選択"
 
 #. type: paragraph
-#: modules/configuration.org:309
+#: modules/configuration.org:313
 msgid ""
 "The =ssh-ng= protocol is preferred over plain =ssh= because it supports "
 "content-addressed derivations and more efficient store path transfers. "
@@ -7130,13 +7155,13 @@ msgstr ""
 "づいてプロトコルが動的に選択されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:314
+#: modules/configuration.org:318
 #, no-wrap
 msgid "build-machines-let"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:316
+#: modules/configuration.org:320
 #, no-wrap
 msgid ""
 "protocol = if (config.services ? hydra && config.services.hydra.enable) then \"ssh\" else \"ssh-ng\";\n"
@@ -7145,13 +7170,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:323
+#: modules/configuration.org:327
 #, no-wrap
 msgid "distributed-builds-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:325
+#: modules/configuration.org:329
 #, no-wrap
 msgid ""
 "nix = {\n"
@@ -7159,7 +7184,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:328
+#: modules/configuration.org:332
 #, no-wrap
 msgid ""
 "extraOptions = ''\n"
@@ -7168,7 +7193,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:332
+#: modules/configuration.org:336
 #, no-wrap
 msgid ""
 "  <<build-machines-list>>\n"
@@ -7176,13 +7201,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:336
+#: modules/configuration.org:340
 #, no-wrap
 msgid "Build Machines"
 msgstr "ビルドマシン"
 
 #. type: paragraph
-#: modules/configuration.org:338
+#: modules/configuration.org:342
 msgid ""
 "Each machine excludes itself from the build machine list (via "
 "=config.networking.hostName= checks) to avoid circular build delegation. The "
@@ -7195,7 +7220,7 @@ msgstr ""
 "フロードすべきではないためです。"
 
 #. type: paragraph
-#: modules/configuration.org:343
+#: modules/configuration.org:347
 msgid ""
 "Machine capabilities (=maxJobs=, =system-features=) are referenced from each "
 "machine's configuration rather than hardcoded. See each machine's definition "
@@ -7207,13 +7232,13 @@ msgstr ""
 "ださい（例: =systems/nixos/tarangire/default.nix= の =max-jobs = 12=）。"
 
 #. type: keyword NAME
-#: modules/configuration.org:347
+#: modules/configuration.org:351
 #, no-wrap
 msgid "build-machines-list"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:349
+#: modules/configuration.org:353
 #, no-wrap
 msgid ""
 "buildMachines =\n"
@@ -7275,13 +7300,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:407
+#: modules/configuration.org:411
 #, no-wrap
 msgid "SSH Known Hosts"
 msgstr "SSH Known Hosts"
 
 #. type: paragraph
-#: modules/configuration.org:409
+#: modules/configuration.org:413
 msgid ""
 "Distributed builds connect to remote machines over SSH, so each build "
 "machine's host key must be registered to avoid interactive verification "
@@ -7291,13 +7316,13 @@ msgstr ""
 "プロンプトを避けるために各ビルドマシンのホスト鍵を登録する必要があります。"
 
 #. type: keyword NAME
-#: modules/configuration.org:412
+#: modules/configuration.org:416
 #, no-wrap
 msgid "build-machines-known-hosts"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:414
+#: modules/configuration.org:418
 #, no-wrap
 msgid ""
 "programs.ssh.knownHosts = {\n"
@@ -7309,13 +7334,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:422
+#: modules/configuration.org:426
 #, no-wrap
 msgid "User-Level Settings"
 msgstr "ユーザーレベルの設定"
 
 #. type: paragraph
-#: modules/configuration.org:424
+#: modules/configuration.org:428
 msgid ""
 "User-level Nix settings, managed through home-manager because they belong to "
 "the user's environment rather than the system configuration."
@@ -7324,7 +7349,7 @@ msgstr ""
 "home-managerで管理されています。"
 
 #. type: paragraph
-#: modules/configuration.org:427
+#: modules/configuration.org:431
 msgid ""
 "XDG base directories are enabled to keep =~/.nix-defexpr= and =~/.nix-"
 "profile= under =~/.config/nix/= and =~/.local/state/nix/=, respectively, "
@@ -7335,7 +7360,7 @@ msgstr ""
 "トファイルの散らかりを減らします。"
 
 #. type: paragraph
-#: modules/configuration.org:431
+#: modules/configuration.org:435
 msgid ""
 "The =result= symlink is added to git ignores because =nix build= creates "
 "=result= symlinks in the project root by default, and these should never be "
@@ -7348,7 +7373,7 @@ msgstr ""
 "ルgitignoreに適用されます。"
 
 #. type: paragraph in src
-#: modules/configuration.org:441
+#: modules/configuration.org:445
 #, no-wrap
 msgid ""
 "{ config, ... }:\n"
@@ -7357,7 +7382,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:445
+#: modules/configuration.org:449
 #, no-wrap
 msgid ""
 "  programs.git.ignores = [ \"result\" ];\n"
@@ -7365,19 +7390,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:449 modules/configuration.org:557
+#: modules/configuration.org:453 modules/configuration.org:561
 #, no-wrap
 msgid "Networking"
 msgstr "ネットワーク"
 
 #. type: heading **
-#: modules/configuration.org:451
+#: modules/configuration.org:455
 #, no-wrap
 msgid "Tailscale"
 msgstr "Tailscale"
 
 #. type: paragraph
-#: modules/configuration.org:453
+#: modules/configuration.org:457
 msgid ""
 "Opinionated Tailscale VPN configuration for NixOS systems. This module "
 "provides sensible defaults for running Tailscale with MagicDNS, SSH access, "
@@ -7388,7 +7413,7 @@ msgstr ""
 "デフォルトを提供します。"
 
 #. type: paragraph in src
-#: modules/configuration.org:462
+#: modules/configuration.org:466
 #, no-wrap
 msgid ""
 "{ config, lib, ... }:\n"
@@ -7400,7 +7425,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:469
+#: modules/configuration.org:473
 #, no-wrap
 msgid ""
 "  <<tailscale-config>>\n"
@@ -7408,18 +7433,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:475
+#: modules/configuration.org:479
 msgid "Module options for controlling Tailscale behavior."
 msgstr "Tailscaleの動作を制御するモジュールオプションです。"
 
 #. type: keyword NAME
-#: modules/configuration.org:477
+#: modules/configuration.org:481
 #, no-wrap
 msgid "tailscale-options"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:479
+#: modules/configuration.org:483
 #, no-wrap
 msgid ""
 "options.my.services.tailscale = {\n"
@@ -7427,7 +7452,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:482
+#: modules/configuration.org:486
 #, no-wrap
 msgid ""
 "  <<configureResolver-option>>\n"
@@ -7435,13 +7460,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:486
+#: modules/configuration.org:490
 #, no-wrap
 msgid "configureResolver"
 msgstr "configureResolver"
 
 #. type: paragraph
-#: modules/configuration.org:488
+#: modules/configuration.org:492
 msgid ""
 "Desktop systems may experience DNS resolution failures after suspend/resume. "
 "When the system resumes, external domain resolution (e.g., github.com) fails "
@@ -7454,7 +7479,7 @@ msgstr ""
 "時のTailscaleのDNS状態管理に関する既知の問題です。"
 
 #. type: paragraph
-#: modules/configuration.org:492
+#: modules/configuration.org:496
 msgid ""
 "Enabling =configureResolver= activates systemd-resolved, which helps "
 "mitigate DNS resolution issues after suspend/resume. While this doesn't "
@@ -7467,7 +7492,7 @@ msgstr ""
 "MagicDNS体験を提供します。"
 
 #. type: paragraph
-#: modules/configuration.org:496
+#: modules/configuration.org:500
 msgid ""
 "For headless servers, this option is typically unnecessary because servers "
 "don't suspend, and thus never encounter this resume-related DNS bug."
@@ -7476,7 +7501,7 @@ msgstr ""
 "ないため、レジュームに関連するこのDNSバグに遭遇することがないためです。"
 
 #. type: paragraph
-#: modules/configuration.org:499
+#: modules/configuration.org:503
 msgid ""
 "See [[https://github.com/tailscale/tailscale/issues/4254][tailscale/"
 "tailscale#4254]] for the upstream discussion."
@@ -7485,13 +7510,13 @@ msgstr ""
 "4254][tailscale/tailscale#4254]]を参照してください。"
 
 #. type: keyword NAME
-#: modules/configuration.org:501
+#: modules/configuration.org:505
 #, no-wrap
 msgid "configureResolver-option"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:503
+#: modules/configuration.org:507
 #, no-wrap
 msgid ""
 "configureResolver = lib.mkOption {\n"
@@ -7506,13 +7531,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: modules/configuration.org:516
+#: modules/configuration.org:520
 #, no-wrap
 msgid "tailscale-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:518
+#: modules/configuration.org:522
 #, no-wrap
 msgid ""
 "config = lib.mkIf cfg.enable (\n"
@@ -7522,13 +7547,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:523
+#: modules/configuration.org:527
 #, no-wrap
 msgid "<<tailscale-networking>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:525
+#: modules/configuration.org:529
 #, no-wrap
 msgid ""
 "      <<tailscale-secrets>>\n"
@@ -7539,18 +7564,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:532
+#: modules/configuration.org:536
 #, no-wrap
 msgid "Service Settings"
 msgstr "サービス設定"
 
 #. type: paragraph
-#: modules/configuration.org:534
+#: modules/configuration.org:538
 msgid "Core Tailscale service configuration."
 msgstr "Tailscaleサービスのコア設定"
 
 #. type: paragraph
-#: modules/configuration.org:536
+#: modules/configuration.org:540
 msgid ""
 "=useRoutingFeatures = \"server\"= enables this machine to act as a subnet "
 "router or exit node.  All machines in this configuration can potentially "
@@ -7563,7 +7588,7 @@ msgstr ""
 "します。"
 
 #. type: paragraph
-#: modules/configuration.org:540
+#: modules/configuration.org:544
 msgid ""
 "=authKeyFile= points to a SOPS-managed secret containing a Tailscale auth "
 "key. Using auth keys enables unattended authentication, which is essential "
@@ -7574,7 +7599,7 @@ msgstr ""
 "イやGitOpsワークフローに不可欠です。"
 
 #. type: paragraph
-#: modules/configuration.org:544
+#: modules/configuration.org:548
 msgid ""
 "=--ssh= enables Tailscale SSH, allowing SSH access over the Tailscale "
 "network without managing SSH keys or exposing port 22 to the public internet."
@@ -7584,13 +7609,13 @@ msgstr ""
 "す。"
 
 #. type: keyword NAME
-#: modules/configuration.org:547
+#: modules/configuration.org:551
 #, no-wrap
 msgid "tailscale-service"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:549
+#: modules/configuration.org:553
 #, no-wrap
 msgid ""
 "services.tailscale = {\n"
@@ -7602,12 +7627,12 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:559
+#: modules/configuration.org:563
 msgid "Firewall and DNS configuration for Tailscale integration."
 msgstr "Tailscale統合のためのファイアウォールとDNS設定です。"
 
 #. type: paragraph
-#: modules/configuration.org:561
+#: modules/configuration.org:565
 msgid ""
 "The =tailscale0= interface is trusted because all traffic on this interface "
 "is authenticated by Tailscale. This allows services to be exposed only to "
@@ -7618,7 +7643,7 @@ msgstr ""
 "イアウォールルールなしにサービスをtailnetのみに公開できます。"
 
 #. type: paragraph
-#: modules/configuration.org:565
+#: modules/configuration.org:569
 msgid ""
 "=100.100.100.100= is Tailscale's MagicDNS resolver, enabling resolution of "
 "tailnet hostnames (e.g., =hostname.tail4108.ts.net=). =8.8.8.8= provides "
@@ -7631,7 +7656,7 @@ msgstr ""
 "バーへの転送を処理します。"
 
 #. type: paragraph
-#: modules/configuration.org:569
+#: modules/configuration.org:573
 msgid ""
 "The search domain is the tailnet domain, allowing short hostnames (e.g., "
 "=ssh manyara= instead of =ssh manyara.tail4108.ts.net=)."
@@ -7640,13 +7665,13 @@ msgstr ""
 "manyara.tail4108.ts.net= の代わりに =ssh manyara=）が使えます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:572
+#: modules/configuration.org:576
 #, no-wrap
 msgid "tailscale-networking"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:574
+#: modules/configuration.org:578
 #, no-wrap
 msgid ""
 "networking = {\n"
@@ -7663,13 +7688,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:587
+#: modules/configuration.org:591
 #, no-wrap
 msgid "Secrets"
 msgstr "シークレット"
 
 #. type: paragraph
-#: modules/configuration.org:589
+#: modules/configuration.org:593
 msgid ""
 "SOPS secret declaration for the Tailscale auth key. The actual key is stored "
 "encrypted in the repository's secrets file and decrypted at activation time."
@@ -7678,25 +7703,25 @@ msgstr ""
 "レットファイルに暗号化されて保存され、アクティベーション時に復号されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:592
+#: modules/configuration.org:596
 #, no-wrap
 msgid "tailscale-secrets"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:594
+#: modules/configuration.org:598
 #, no-wrap
 msgid "sops.secrets.tailscale-authkey = { };"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:597
+#: modules/configuration.org:601
 #, no-wrap
 msgid "Resolver"
 msgstr "リゾルバー"
 
 #. type: paragraph
-#: modules/configuration.org:599
+#: modules/configuration.org:603
 msgid ""
 "Conditional systemd-resolved configuration. Only enabled when "
 "=configureResolver= is true, typically on desktop systems that suspend/"
@@ -7706,13 +7731,13 @@ msgstr ""
 "効になり、通常はサスペンド/レジュームするデスクトップシステムで使用されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:602
+#: modules/configuration.org:606
 #, no-wrap
 msgid "tailscale-resolver"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:604
+#: modules/configuration.org:608
 #, no-wrap
 msgid ""
 "(lib.mkIf cfg.configureResolver {\n"
@@ -7721,13 +7746,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:609
+#: modules/configuration.org:613
 #, no-wrap
 msgid "Shell"
 msgstr "シェル"
 
 #. type: paragraph
-#: modules/configuration.org:611
+#: modules/configuration.org:615
 msgid ""
 "Interactive shells and scripting shells serve different purposes. An "
 "interactive shell does not need to be POSIX-compatible — what matters is "
@@ -7737,13 +7762,13 @@ msgstr ""
 "換である必要はなく、重要なのは使いやすさ、幅広い環境サポート、拡張性です。"
 
 #. type: heading **
-#: modules/configuration.org:615
+#: modules/configuration.org:619
 #, no-wrap
 msgid "Fish"
 msgstr "Fish"
 
 #. type: paragraph
-#: modules/configuration.org:617
+#: modules/configuration.org:621
 msgid ""
 "Fish is the primary interactive shell, chosen for its out-of-the-box "
 "experience: syntax highlighting, autosuggestions, and tab completions work "
@@ -7757,7 +7782,7 @@ msgstr ""
 "小限のセットアップで最も便利で拡張可能な対話的エクスペリエンスを提供します。"
 
 #. type: paragraph in src
-#: modules/configuration.org:628
+#: modules/configuration.org:632
 #, no-wrap
 msgid ""
 "{ pkgs, ... }:\n"
@@ -7767,25 +7792,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:633
+#: modules/configuration.org:637
 #, no-wrap
 msgid "<<fish-interactive-shell-init>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:635
+#: modules/configuration.org:639
 #, no-wrap
 msgid "<<fish-abbreviations>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:637
+#: modules/configuration.org:641
 #, no-wrap
 msgid "<<fish-functions>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:639
+#: modules/configuration.org:643
 #, no-wrap
 msgid ""
 "    <<fish-plugins>>\n"
@@ -7794,13 +7819,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:644
+#: modules/configuration.org:648
 #, no-wrap
 msgid "Interactive Shell Init"
 msgstr "対話シェルの初期化"
 
 #. type: paragraph
-#: modules/configuration.org:646
+#: modules/configuration.org:650
 msgid ""
 "Settings applied when fish starts an interactive session: keybindings, "
 "plugin configuration, environment variables, and shell integrations."
@@ -7809,13 +7834,13 @@ msgstr ""
 "ン設定、環境変数、シェル統合が含まれます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:649
+#: modules/configuration.org:653
 #, no-wrap
 msgid "fish-interactive-shell-init"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:651
+#: modules/configuration.org:655
 #, no-wrap
 msgid ""
 "interactiveShellInit = ''\n"
@@ -7823,25 +7848,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:654
+#: modules/configuration.org:658
 #, no-wrap
 msgid "<<fish-done-config>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:656
+#: modules/configuration.org:660
 #, no-wrap
 msgid "<<fish-pinentry>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:658
+#: modules/configuration.org:662
 #, no-wrap
 msgid "<<fish-extra-abbrs>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:660
+#: modules/configuration.org:664
 #, no-wrap
 msgid ""
 "  <<fish-any-nix-shell>>\n"
@@ -7849,13 +7874,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:664
+#: modules/configuration.org:668
 #, no-wrap
 msgid "Keybindings"
 msgstr "キーバインド"
 
 #. type: paragraph
-#: modules/configuration.org:666
+#: modules/configuration.org:670
 msgid ""
 "=Ctrl+S= is bound to =zi= ([[https://github.com/ajeetdsouza/zoxide][zoxide]] "
 "interactive mode) for fuzzy directory jumping."
@@ -7864,25 +7889,25 @@ msgstr ""
 "クティブモード）をバインドし、ファジーなディレクトリジャンプに使用します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:668
+#: modules/configuration.org:672
 #, no-wrap
 msgid "fish-keybindings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:670
+#: modules/configuration.org:674
 #, no-wrap
 msgid "bind \\cs zi"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:673
+#: modules/configuration.org:677
 #, no-wrap
 msgid "Pinentry"
 msgstr "Pinentry"
 
 #. type: paragraph
-#: modules/configuration.org:675
+#: modules/configuration.org:679
 msgid ""
 "When connected via SSH, GPG's pinentry is switched to the curses (terminal) "
 "variant.  The default graphical pinentry cannot display on a remote session "
@@ -7899,13 +7924,13 @@ msgstr ""
 "pinentry for SSH logins]]を参照してください。"
 
 #. type: keyword NAME
-#: modules/configuration.org:680
+#: modules/configuration.org:684
 #, no-wrap
 msgid "fish-pinentry"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:683
+#: modules/configuration.org:687
 #, no-wrap
 msgid ""
 "if test \"$SSH_CONNECTION\" != \"\"\n"
@@ -7914,13 +7939,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:688
+#: modules/configuration.org:692
 #, no-wrap
 msgid "Extra Abbreviations"
 msgstr "追加の略語"
 
 #. type: paragraph
-#: modules/configuration.org:690
+#: modules/configuration.org:694
 msgid ""
 "Position-aware [[https://fishshell.com/docs/current/cmds/abbr.html]"
 "[abbreviations]] that use fish's advanced features (=--position anywhere=, "
@@ -7932,13 +7957,13 @@ msgstr ""
 "います。これらはhome-managerの =shellAbbrs= オプションでは利用できません。"
 
 #. type: keyword NAME
-#: modules/configuration.org:693
+#: modules/configuration.org:697
 #, no-wrap
 msgid "fish-extra-abbrs"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:696
+#: modules/configuration.org:700
 #, no-wrap
 msgid ""
 "abbr -a L --position anywhere --set-cursor \"% | less\"\n"
@@ -7948,13 +7973,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:702
+#: modules/configuration.org:706
 #, no-wrap
 msgid "any-nix-shell"
 msgstr "any-nix-shell"
 
 #. type: paragraph
-#: modules/configuration.org:704
+#: modules/configuration.org:708
 msgid ""
 "[[https://github.com/haslersn/any-nix-shell][any-nix-shell]] keeps fish as "
 "the interactive shell inside =nix shell= and =nix develop= environments. "
@@ -7970,31 +7995,31 @@ msgstr ""
 "できるよう、=interactiveShellInit= の末尾でソースされます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:710
+#: modules/configuration.org:714
 #, no-wrap
 msgid "fish-any-nix-shell"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:712
+#: modules/configuration.org:716
 #, no-wrap
 msgid "${pkgs.any-nix-shell}/bin/any-nix-shell fish | source"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:715
+#: modules/configuration.org:719
 #, no-wrap
 msgid "Abbreviations"
 msgstr "略語"
 
 #. type: keyword NAME
-#: modules/configuration.org:717
+#: modules/configuration.org:721
 #, no-wrap
 msgid "fish-abbreviations"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:719
+#: modules/configuration.org:723
 #, no-wrap
 msgid ""
 "shellAbbrs = {\n"
@@ -8002,7 +8027,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:722
+#: modules/configuration.org:726
 #, no-wrap
 msgid ""
 "  <<fish-abbr-nix>>\n"
@@ -8010,31 +8035,31 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:726
+#: modules/configuration.org:730
 #, no-wrap
 msgid "General"
 msgstr "一般"
 
 #. type: keyword NAME
-#: modules/configuration.org:728
+#: modules/configuration.org:732
 #, no-wrap
 msgid "fish-abbr-general"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:731
+#: modules/configuration.org:735
 #, no-wrap
 msgid "l = \"ls\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:734
+#: modules/configuration.org:738
 #, no-wrap
 msgid "Nix Remote Build"
 msgstr "Nixリモートビルド"
 
 #. type: paragraph
-#: modules/configuration.org:736
+#: modules/configuration.org:740
 msgid ""
 "Abbreviations for specifying Nix build target systems, primarily used when "
 "working on nixpkgs. Each abbreviation expands to =--system <triple>= and "
@@ -8052,13 +8077,13 @@ msgstr ""
 "クチャの不一致で失敗することを防ぎます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:743
+#: modules/configuration.org:747
 #, no-wrap
 msgid "fish-abbr-nix"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:745
+#: modules/configuration.org:749
 #, no-wrap
 msgid ""
 "\"--sxl\" = {\n"
@@ -8090,13 +8115,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:774
+#: modules/configuration.org:778
 #, no-wrap
 msgid "Functions"
 msgstr "関数"
 
 #. type: paragraph
-#: modules/configuration.org:776
+#: modules/configuration.org:780
 msgid ""
 "Helper functions used by the abbreviation system. These are separated from "
 "the abbreviation definitions because fish requires functions to be defined "
@@ -8106,13 +8131,13 @@ msgstr ""
 "る前に関数を定義する必要があるため、略語の定義とは分離されています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:780
+#: modules/configuration.org:784
 #, no-wrap
 msgid "fish-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:782
+#: modules/configuration.org:786
 #, no-wrap
 msgid ""
 "functions = {\n"
@@ -8123,19 +8148,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:789
+#: modules/configuration.org:793
 #, no-wrap
 msgid "Plugins"
 msgstr "プラグイン"
 
 #. type: keyword NAME
-#: modules/configuration.org:791
+#: modules/configuration.org:795
 #, no-wrap
 msgid "fish-plugins"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:793
+#: modules/configuration.org:797
 #, no-wrap
 msgid ""
 "plugins = [\n"
@@ -8151,7 +8176,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:805
+#: modules/configuration.org:809
 msgid ""
 "The [[https://github.com/franciscolourenco/done][done]] plugin provides "
 "desktop notifications for long-running commands.  The threshold is set to 15 "
@@ -8167,19 +8192,19 @@ msgstr ""
 "が有用です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:811
+#: modules/configuration.org:815
 #, no-wrap
 msgid "fish-done-config"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:814
+#: modules/configuration.org:818
 #, no-wrap
 msgid "set -U __done_min_cmd_duration 15000"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:817
+#: modules/configuration.org:821
 msgid ""
 "[[https://github.com/PatrickF1/fzf.fish][fzf-fish]] integrates fzf with "
 "fish's tab completion, history search, and file/directory navigation. It "
@@ -8192,13 +8217,13 @@ msgstr ""
 "処理します。"
 
 #. type: heading **
-#: modules/configuration.org:821
+#: modules/configuration.org:825
 #, no-wrap
 msgid "Bash"
 msgstr "Bash"
 
 #. type: paragraph
-#: modules/configuration.org:823
+#: modules/configuration.org:827
 msgid ""
 "Bash is configured as a minimal fallback shell rather than a full "
 "interactive environment. The primary use case is ensuring a usable shell "
@@ -8214,7 +8239,7 @@ msgstr ""
 "あれば、問題がfish固有かどうかの切り分けに役立ちます。"
 
 #. type: paragraph in src
-#: modules/configuration.org:836
+#: modules/configuration.org:840
 #, no-wrap
 msgid ""
 "{\n"
@@ -8230,25 +8255,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:847
+#: modules/configuration.org:851
 #, no-wrap
 msgid "<<bash-history>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:849
+#: modules/configuration.org:853
 #, no-wrap
 msgid "<<bash-completion>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:851
+#: modules/configuration.org:855
 #, no-wrap
 msgid "<<bash-aliases>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:853
+#: modules/configuration.org:857
 #, no-wrap
 msgid ""
 "    <<bash-init>>\n"
@@ -8257,13 +8282,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:858
+#: modules/configuration.org:862
 #, no-wrap
 msgid "History"
 msgstr "履歴"
 
 #. type: paragraph
-#: modules/configuration.org:860
+#: modules/configuration.org:864
 msgid ""
 "History is stored under =XDG_CONFIG_HOME= to keep =$HOME= clean, consistent "
 "with the repository's preference for XDG base directories (see [[*User-Level "
@@ -8274,25 +8299,25 @@ msgstr ""
 "[ユーザーレベルの設定]]参照）。"
 
 #. type: keyword NAME
-#: modules/configuration.org:863
+#: modules/configuration.org:867
 #, no-wrap
 msgid "bash-history"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:865
+#: modules/configuration.org:869
 #, no-wrap
 msgid "historyFile = \"$XDG_CONFIG_HOME/bash/history\";"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:868
+#: modules/configuration.org:872
 #, no-wrap
 msgid "Completion"
 msgstr "補完"
 
 #. type: paragraph
-#: modules/configuration.org:870
+#: modules/configuration.org:874
 msgid ""
 "Bash completion is disabled because bash is not used as the primary "
 "interactive shell. Loading completion scripts adds startup time (~100ms+) "
@@ -8304,25 +8329,25 @@ msgstr ""
 "ルバックやスクリプト実行にのみ使用するシェルではメリットがありません。"
 
 #. type: keyword NAME
-#: modules/configuration.org:874
+#: modules/configuration.org:878
 #, no-wrap
 msgid "bash-completion"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:876
+#: modules/configuration.org:880
 #, no-wrap
 msgid "enableCompletion = false;"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:879
+#: modules/configuration.org:883
 #, no-wrap
 msgid "Aliases"
 msgstr "エイリアス"
 
 #. type: paragraph
-#: modules/configuration.org:881
+#: modules/configuration.org:885
 msgid ""
 "Basic aliases that provide a minimal quality-of-life improvement if bash is "
 "used interactively. These are intentionally simple — fish handles the rich "
@@ -8333,13 +8358,13 @@ msgstr ""
 "ます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:885
+#: modules/configuration.org:889
 #, no-wrap
 msgid "bash-aliases"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:887
+#: modules/configuration.org:891
 #, no-wrap
 msgid ""
 "shellAliases = {\n"
@@ -8351,13 +8376,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:895
+#: modules/configuration.org:899
 #, no-wrap
 msgid "Init"
 msgstr "初期化"
 
 #. type: paragraph
-#: modules/configuration.org:897
+#: modules/configuration.org:901
 msgid ""
 "This configuration is a remnant from before fish was set as the default "
 "login shell.  Previously, bash was the login shell and =.bashrc= launched "
@@ -8370,13 +8395,13 @@ msgstr ""
 "持されています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:902
+#: modules/configuration.org:906
 #, no-wrap
 msgid "bash-init"
 msgstr ""
 
 #. type: plain list +
-#: modules/configuration.org:909
+#: modules/configuration.org:913
 #, no-wrap
 msgid ""
 "lib.optionalString (!config.programs.kitty.enable) ''\n"
@@ -8384,7 +8409,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:904
+#: modules/configuration.org:908
 #, no-wrap
 msgid ""
 "initExtra = ''\n"
@@ -8394,13 +8419,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:912
+#: modules/configuration.org:916
 #, no-wrap
 msgid "Terminal Settings"
 msgstr "ターミナル設定"
 
 #. type: plain list -
-#: modules/configuration.org:918
+#: modules/configuration.org:922
 #, no-wrap
 msgid ""
 "=stty stop undef=: Disables =Ctrl+S= from sending =XOFF= (terminal pause), freeing\n"
@@ -8414,7 +8439,7 @@ msgstr ""
 "これは現代のターミナルではほとんど役に立たないレガシーなフロー制御機構です。"
 
 #. type: plain list -
-#: modules/configuration.org:921
+#: modules/configuration.org:925
 #, no-wrap
 msgid ""
 "=stty werase undef= + =bind \"\\C-w\":unix-filename-rubout=: Rebinds =Ctrl+W= to delete\n"
@@ -8426,13 +8451,13 @@ msgstr ""
 "シェルでの一般的なケースであるファイルパスの編集時に、より便利です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:922
+#: modules/configuration.org:926
 #, no-wrap
 msgid "bash-terminal-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:924
+#: modules/configuration.org:928
 #, no-wrap
 msgid ""
 "stty stop undef  # Ctrl-s\n"
@@ -8441,13 +8466,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:929
+#: modules/configuration.org:933
 #, no-wrap
 msgid "TMUX Auto-attach"
 msgstr "TMUXの自動アタッチ"
 
 #. type: paragraph
-#: modules/configuration.org:931
+#: modules/configuration.org:935
 msgid ""
 "Automatically starts or attaches to a tmux session when bash is the "
 "interactive shell, but only when kitty is not the terminal emulator. Kitty "
@@ -8465,13 +8490,13 @@ msgstr ""
 "以外では欠けるセッション永続性とウィンドウ管理を提供します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:938
+#: modules/configuration.org:942
 #, no-wrap
 msgid "bash-tmux-autostart"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:941
+#: modules/configuration.org:945
 #, no-wrap
 msgid ""
 "if type tmux > /dev/null 2>&1; then\n"
@@ -8479,7 +8504,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:946
+#: modules/configuration.org:950
 #, no-wrap
 msgid ""
 "  while test -z $TMUX; do\n"
@@ -8489,13 +8514,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:952
+#: modules/configuration.org:956
 #, no-wrap
 msgid "Nushell"
 msgstr "Nushell"
 
 #. type: paragraph
-#: modules/configuration.org:954
+#: modules/configuration.org:958
 msgid ""
 "Nushell is enabled for its ability to handle structured data natively, "
 "similar to PowerShell. Where traditional shells pipe text between commands, "
@@ -8512,7 +8537,7 @@ msgstr ""
 "換性は要件ではありません。"
 
 #. type: paragraph
-#: modules/configuration.org:961
+#: modules/configuration.org:965
 msgid ""
 "No custom configuration is added yet — the defaults are sufficient for "
 "exploratory use, and committing to Nushell-specific workflows would be "
@@ -8522,7 +8547,7 @@ msgstr ""
 "り、Nushell固有のワークフローにコミットするのは時期尚早です。"
 
 #. type: paragraph in src
-#: modules/configuration.org:970
+#: modules/configuration.org:974
 #, no-wrap
 msgid ""
 "{ config, ... }:\n"
@@ -8534,13 +8559,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:978
+#: modules/configuration.org:982
 #, no-wrap
 msgid "Starship"
 msgstr "Starship"
 
 #. type: paragraph
-#: modules/configuration.org:980
+#: modules/configuration.org:984
 msgid ""
 "[[https://starship.rs/][Starship]] is a cross-shell prompt written in Rust, "
 "used across all shells configured here to provide a consistent prompt "
@@ -8554,7 +8579,7 @@ msgstr ""
 "から使用されており、簡単なTOMLベースの設定が使い続けている主な理由です。"
 
 #. type: paragraph
-#: modules/configuration.org:984
+#: modules/configuration.org:988
 msgid ""
 "Starship does not natively support asynchronous prompt rendering, so this "
 "section also includes a custom async prompt module for fish."
@@ -8564,7 +8589,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph in src
-#: modules/configuration.org:993
+#: modules/configuration.org:997
 #, no-wrap
 msgid ""
 "{ pkgs, ... }:\n"
@@ -8578,13 +8603,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1008
+#: modules/configuration.org:1012
 #, no-wrap
 msgid "Prompt Format"
 msgstr "プロンプトフォーマット"
 
 #. type: paragraph
-#: modules/configuration.org:1010
+#: modules/configuration.org:1014
 msgid ""
 "The prompt format prepends a shell indicator before the default modules.  "
 "This makes it immediately visible which shell is active, useful when "
@@ -8595,25 +8620,25 @@ msgstr ""
 "グでfishとbashを切り替える際に便利です。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1015
+#: modules/configuration.org:1019
 #, no-wrap
 msgid "\"$schema\" = \"https://starship.rs/config-schema.json\""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1017
+#: modules/configuration.org:1021
 #, no-wrap
 msgid "format = \"$shell$all$line_break$character\""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1020
+#: modules/configuration.org:1024
 #, no-wrap
 msgid "Shell Indicator"
 msgstr "シェルインジケーター"
 
 #. type: paragraph
-#: modules/configuration.org:1022
+#: modules/configuration.org:1026
 msgid ""
 "Each shell has a distinct icon: =󰈺= (fish icon) for fish. Bash and nushell "
 "use the default indicator."
@@ -8622,7 +8647,7 @@ msgstr ""
 "nushellはデフォルトのインジケーターを使用します。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1026
+#: modules/configuration.org:1030
 #, no-wrap
 msgid ""
 "[shell]\n"
@@ -8632,13 +8657,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1032
+#: modules/configuration.org:1036
 #, no-wrap
 msgid "Remote Container Detection"
 msgstr "リモートコンテナの検出"
 
 #. type: paragraph
-#: modules/configuration.org:1034
+#: modules/configuration.org:1038
 msgid ""
 "A custom module detects when running inside a VS Code Remote Container (Dev "
 "Container) by checking the =REMOTE_CONTAINERS= environment variable, "
@@ -8651,7 +8676,7 @@ msgstr ""
 "らず、もう関連性がないかもしれません。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1040
+#: modules/configuration.org:1044
 #, no-wrap
 msgid ""
 "[custom.remote-container]\n"
@@ -8661,13 +8686,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1046
+#: modules/configuration.org:1050
 #, no-wrap
 msgid "Disabled Modules"
 msgstr "無効化されたモジュール"
 
 #. type: paragraph
-#: modules/configuration.org:1048
+#: modules/configuration.org:1052
 msgid ""
 "=gcloud= is disabled because it reads the active GCP configuration from the "
 "home directory (=~/.config/gcloud/=), causing it to appear in every "
@@ -8678,7 +8703,7 @@ msgstr ""
 "なく、すべてのリポジトリで表示されてしまいます。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1053
+#: modules/configuration.org:1057
 #, no-wrap
 msgid ""
 "[gcloud]\n"
@@ -8686,13 +8711,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1057
+#: modules/configuration.org:1061
 #, no-wrap
 msgid "Async Prompt Module"
 msgstr "非同期プロンプトモジュール"
 
 #. type: paragraph
-#: modules/configuration.org:1059
+#: modules/configuration.org:1063
 msgid ""
 "A custom home-manager module that replaces starship's default fish "
 "integration with an asynchronous variant. The async prompt script is cherry-"
@@ -8711,7 +8736,7 @@ msgstr ""
 "さい。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1070
+#: modules/configuration.org:1074
 #, no-wrap
 msgid ""
 "{\n"
@@ -8742,7 +8767,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1097
+#: modules/configuration.org:1101
 #, no-wrap
 msgid ""
 "    programs.fish.interactiveShellInit = ''\n"
@@ -8756,13 +8781,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1107
+#: modules/configuration.org:1111
 #, no-wrap
 msgid "Async Prompt Script"
 msgstr "非同期プロンプトスクリプト"
 
 #. type: paragraph in src
-#: modules/configuration.org:1116
+#: modules/configuration.org:1120
 #, no-wrap
 msgid ""
 "status is-interactive\n"
@@ -8770,7 +8795,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1119
+#: modules/configuration.org:1123
 #, no-wrap
 msgid ""
 "if test -n \"$XDG_RUNTIME_DIR\"\n"
@@ -8783,7 +8808,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1128
+#: modules/configuration.org:1132
 #, no-wrap
 msgid ""
 "set -g VIRTUAL_ENV_DISABLE_PROMPT 1\n"
@@ -8793,7 +8818,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1134
+#: modules/configuration.org:1138
 #, no-wrap
 msgid ""
 "function fish_prompt\n"
@@ -8807,7 +8832,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1144
+#: modules/configuration.org:1148
 #, no-wrap
 msgid ""
 "function __starship_async_fire --on-event fish_prompt\n"
@@ -8824,7 +8849,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1156
+#: modules/configuration.org:1160
 #, no-wrap
 msgid ""
 "    set -l tmpfile \"$__starship_async_tmpdir\"/\"$fish_pid\"_fish_prompt\n"
@@ -8836,7 +8861,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1163
+#: modules/configuration.org:1167
 #, no-wrap
 msgid ""
 "function __starship_async_simple_prompt\n"
@@ -8848,7 +8873,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1170
+#: modules/configuration.org:1174
 #, no-wrap
 msgid ""
 "function __starship_async_repaint_prompt --on-signal \"$__starship_async_signal\"\n"
@@ -8857,7 +8882,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1174
+#: modules/configuration.org:1178
 #, no-wrap
 msgid ""
 "function __starship_async_cleanup --on-event fish_exit\n"
@@ -8866,19 +8891,19 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1182
+#: modules/configuration.org:1186
 #, no-wrap
 msgid "Version Control"
 msgstr "バージョン管理"
 
 #. type: heading **
-#: modules/configuration.org:1184
+#: modules/configuration.org:1188
 #, no-wrap
 msgid "Git"
 msgstr "Git"
 
 #. type: paragraph
-#: modules/configuration.org:1186
+#: modules/configuration.org:1190
 msgid ""
 "Git version control configuration. Git is configured directly through home-"
 "manager's =programs.git= module, which generates =~/.config/git/config= "
@@ -8888,7 +8913,7 @@ msgstr ""
 "じて直接設定され、=~/.config/git/config= を宣言的に生成します。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1195
+#: modules/configuration.org:1199
 #, no-wrap
 msgid ""
 "{ pkgs, config, ... }:\n"
@@ -8898,25 +8923,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1200
+#: modules/configuration.org:1204
 #, no-wrap
 msgid "<<git-settings>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1202
+#: modules/configuration.org:1206
 #, no-wrap
 msgid "<<git-signing>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1204
+#: modules/configuration.org:1208
 #, no-wrap
 msgid "<<git-ignores>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1206
+#: modules/configuration.org:1210
 #, no-wrap
 msgid ""
 "  <<git-scalar>>\n"
@@ -8924,31 +8949,31 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1209
+#: modules/configuration.org:1213
 #, no-wrap
 msgid "<<git-gh>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1211
+#: modules/configuration.org:1215
 #, no-wrap
 msgid "<<git-delta>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1213
+#: modules/configuration.org:1217
 #, no-wrap
 msgid "<<git-difftastic>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1215
+#: modules/configuration.org:1219
 #, no-wrap
 msgid "<<git-lazygit>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1217
+#: modules/configuration.org:1221
 #, no-wrap
 msgid ""
 "  <<git-fish-abbreviations>>\n"
@@ -8956,18 +8981,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1223
+#: modules/configuration.org:1227
 msgid "Basic git behavior settings."
 msgstr "基本的なgitの動作設定です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1225
+#: modules/configuration.org:1229
 #, no-wrap
 msgid "git-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1227
+#: modules/configuration.org:1231
 #, no-wrap
 msgid ""
 "settings = {\n"
@@ -8981,19 +9006,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1237
+#: modules/configuration.org:1241
 #, no-wrap
 msgid "User Identity"
 msgstr "ユーザーID"
 
 #. type: keyword NAME
-#: modules/configuration.org:1239
+#: modules/configuration.org:1243
 #, no-wrap
 msgid "git-user-identity"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1241
+#: modules/configuration.org:1245
 #, no-wrap
 msgid ""
 "user = {\n"
@@ -9003,13 +9028,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1247 modules/configuration.org:1838
+#: modules/configuration.org:1251 modules/configuration.org:1842
 #, no-wrap
 msgid "Editor"
 msgstr "エディター"
 
 #. type: paragraph
-#: modules/configuration.org:1249
+#: modules/configuration.org:1253
 msgid ""
 "=core.editor = \"vim\"= is set as the fallback editor for git operations. "
 "Although the =EDITOR= environment variable is set to =nvim= in the home "
@@ -9024,36 +9049,36 @@ msgstr ""
 "す。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1254
+#: modules/configuration.org:1258
 #, no-wrap
 msgid "git-editor"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1256
+#: modules/configuration.org:1260
 #, no-wrap
 msgid "core.editor = \"vim\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1259
+#: modules/configuration.org:1263
 #, no-wrap
 msgid "Color"
 msgstr "カラー"
 
 #. type: paragraph
-#: modules/configuration.org:1261
+#: modules/configuration.org:1265
 msgid "Auto-detect terminal color support for all git subcommands."
 msgstr "すべてのgitサブコマンドでターミナルのカラーサポートを自動検出します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1263
+#: modules/configuration.org:1267
 #, no-wrap
 msgid "git-color"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1265
+#: modules/configuration.org:1269
 #, no-wrap
 msgid ""
 "color = {\n"
@@ -9066,31 +9091,31 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1274
+#: modules/configuration.org:1278
 #, no-wrap
 msgid "Default Branch"
 msgstr "デフォルトブランチ"
 
 #. type: keyword NAME
-#: modules/configuration.org:1276
+#: modules/configuration.org:1280
 #, no-wrap
 msgid "git-default-branch"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1278
+#: modules/configuration.org:1282
 #, no-wrap
 msgid "init.defaultBranch = \"main\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1281
+#: modules/configuration.org:1285
 #, no-wrap
 msgid "Force Push Safety"
 msgstr "強制プッシュの安全対策"
 
 #. type: paragraph
-#: modules/configuration.org:1283
+#: modules/configuration.org:1287
 msgid ""
 "=push.useForceIfIncludes= enables a safety check for force pushes: git "
 "verifies that the local branch includes the remote's current tip before "
@@ -9107,25 +9132,25 @@ msgstr ""
 "=git fetch=）に検出できません。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1289
+#: modules/configuration.org:1293
 #, no-wrap
 msgid "git-push-safety"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1291
+#: modules/configuration.org:1295
 #, no-wrap
 msgid "push.useForceIfIncludes = true;"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1294
+#: modules/configuration.org:1298
 #, no-wrap
 msgid "URL Rewriting"
 msgstr "URLの書き換え"
 
 #. type: paragraph
-#: modules/configuration.org:1296
+#: modules/configuration.org:1300
 msgid ""
 "=url.\"git@github.com:\".pushInsteadOf= rewrites push URLs from HTTPS to "
 "SSH. This allows =git clone https://github.com/...= to work without SSH "
@@ -9138,7 +9163,7 @@ msgstr ""
 "トークンが不要になります。"
 
 #. type: paragraph
-#: modules/configuration.org:1301
+#: modules/configuration.org:1305
 msgid ""
 "In practice, [[*GitHub CLI][=gh=]] provides its own credential helper that "
 "handles HTTPS authentication transparently, so this rewrite rule may not be "
@@ -9151,25 +9176,25 @@ msgstr ""
 "ています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1305
+#: modules/configuration.org:1309
 #, no-wrap
 msgid "git-url-rewrite"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1307
+#: modules/configuration.org:1311
 #, no-wrap
 msgid "url.\"git@github.com:\".pushInsteadOf = \"https://github.com/\";"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1310
+#: modules/configuration.org:1314
 #, no-wrap
 msgid "Commit Signing"
 msgstr "コミット署名"
 
 #. type: paragraph
-#: modules/configuration.org:1312
+#: modules/configuration.org:1316
 msgid ""
 "SSH-based commit signing. SSH keys were chosen over GPG because SSH keys are "
 "already required for push authentication, eliminating the need to manage a "
@@ -9183,7 +9208,7 @@ msgstr ""
 "合性保証を提供します。認証と署名の両方に1つの鍵ペアで対応できます。"
 
 #. type: paragraph
-#: modules/configuration.org:1317
+#: modules/configuration.org:1321
 msgid ""
 "GitHub has [[https://github.blog/changelog/2022-08-23-ssh-commit-"
 "verification-now-supported/][supported SSH commit verification since August "
@@ -9203,7 +9228,7 @@ msgstr ""
 "点がなくなりました。"
 
 #. type: paragraph
-#: modules/configuration.org:1322
+#: modules/configuration.org:1326
 msgid ""
 "In the future, migrating to a keyless solution like [[https://github.com/"
 "sigstore/gitsign][gitsign]] (Sigstore-based signing)  would further simplify "
@@ -9216,7 +9241,7 @@ msgstr ""
 "トするのを待っている状態です。"
 
 #. type: paragraph
-#: modules/configuration.org:1326
+#: modules/configuration.org:1330
 msgid ""
 "=signByDefault = true= ensures all commits are signed without requiring =git "
 "commit -S=, preventing unsigned commits from slipping through."
@@ -9225,13 +9250,13 @@ msgstr ""
 "名のコミットが紛れ込むのを防ぎます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1329
+#: modules/configuration.org:1333
 #, no-wrap
 msgid "git-signing"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1331
+#: modules/configuration.org:1335
 #, no-wrap
 msgid ""
 "signing = {\n"
@@ -9242,13 +9267,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1338
+#: modules/configuration.org:1342
 #, no-wrap
 msgid "Global Ignores"
 msgstr "グローバルIgnore"
 
 #. type: paragraph
-#: modules/configuration.org:1340
+#: modules/configuration.org:1344
 msgid ""
 "Patterns that should never be committed across all repositories. These are "
 "global ignores rather than per-repo =.gitignore= entries because they "
@@ -9259,13 +9284,13 @@ msgstr ""
 "択を反映しており、共同作業者に押し付けるべきではないためです。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1344
+#: modules/configuration.org:1348
 #, no-wrap
 msgid "git-ignores"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1346
+#: modules/configuration.org:1350
 #, no-wrap
 msgid ""
 "ignores = [\n"
@@ -9277,13 +9302,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1354
+#: modules/configuration.org:1358
 #, no-wrap
 msgid "OS Artifacts"
 msgstr "OSアーティファクト"
 
 #. type: paragraph
-#: modules/configuration.org:1356
+#: modules/configuration.org:1360
 msgid ""
 "macOS Finder metadata files. Present in the global ignore because this is a "
 "cross-platform dotfiles repository used on both Linux and macOS."
@@ -9292,30 +9317,30 @@ msgstr ""
 "ラットフォームなdotfilesリポジトリのため、グローバルignoreに含めています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1359
+#: modules/configuration.org:1363
 #, no-wrap
 msgid "git-ignores-os"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1361
+#: modules/configuration.org:1365
 #, no-wrap
 msgid "\".DS_Store\""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1364
+#: modules/configuration.org:1368
 #, no-wrap
 msgid "Development Environment"
 msgstr "開発環境"
 
 #. type: paragraph
-#: modules/configuration.org:1366
+#: modules/configuration.org:1370
 msgid "Artifacts generated by development tools that should remain local:"
 msgstr "ローカルに留めるべき開発ツールが生成するアーティファクトです："
 
 #. type: plain list -
-#: modules/configuration.org:1370
+#: modules/configuration.org:1374
 #, no-wrap
 msgid ""
 "=.aider*= matches aider's conversation history and configuration files. These contain\n"
@@ -9325,7 +9350,7 @@ msgstr ""
 "セッション固有のコンテキストを含むため、リポジトリに漏れるべきではありません。"
 
 #. type: plain list -
-#: modules/configuration.org:1373
+#: modules/configuration.org:1377
 #, no-wrap
 msgid ""
 "=.direnv=, =.envrc=: direnv state and configuration. Each project may define its own\n"
@@ -9337,13 +9362,13 @@ msgstr ""
 "=.envrc= ファイルは自動生成されコミットすべきではありません。"
 
 #. type: plain list -
-#: modules/configuration.org:1374
+#: modules/configuration.org:1378
 #, no-wrap
 msgid "=.ipynb_checkpoints=: Jupyter Notebook autosave files."
 msgstr "=.ipynb_checkpoints=: Jupyter Notebookの自動保存ファイル。"
 
 #. type: plain list -
-#: modules/configuration.org:1376
+#: modules/configuration.org:1380
 #, no-wrap
 msgid ""
 "=.pre-commit-config.yaml=: Managed per-project by devshell environments rather than committed,\n"
@@ -9353,25 +9378,25 @@ msgstr ""
 "ツールバージョンの異なるコントリビューター間のバージョン競合を避けます。"
 
 #. type: plain list -
-#: modules/configuration.org:1377
+#: modules/configuration.org:1381
 #, no-wrap
 msgid "=.vscode/=: Editor-specific settings that vary per developer."
 msgstr "=.vscode/=: 開発者ごとに異なるエディター固有の設定。"
 
 #. type: plain list -
-#: modules/configuration.org:1378
+#: modules/configuration.org:1382
 #, no-wrap
 msgid "=__pycache__/=: Python bytecode cache, regenerated on each run."
 msgstr "=__pycache__/=: Pythonバイトコードキャッシュ。実行ごとに再生成されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1379
+#: modules/configuration.org:1383
 #, no-wrap
 msgid "git-ignores-dev"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1381
+#: modules/configuration.org:1385
 #, no-wrap
 msgid ""
 "\".aider*\"\n"
@@ -9384,37 +9409,37 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1390
+#: modules/configuration.org:1394
 #, no-wrap
 msgid "Workflow"
 msgstr "ワークフロー"
 
 #. type: plain list -
-#: modules/configuration.org:1393
+#: modules/configuration.org:1397
 #, no-wrap
 msgid "=.worktree=: Marker file used by git worktree workflows."
 msgstr "=.worktree=: git worktreeワークフローで使用されるマーカーファイル。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1394
+#: modules/configuration.org:1398
 #, no-wrap
 msgid "git-ignores-workflow"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1396
+#: modules/configuration.org:1400
 #, no-wrap
 msgid "\".worktree\""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1399
+#: modules/configuration.org:1403
 #, no-wrap
 msgid "Private Notes"
 msgstr "プライベートノート"
 
 #. type: paragraph
-#: modules/configuration.org:1401
+#: modules/configuration.org:1405
 msgid ""
 "=.private/= is a directory for personal notes, LLM context files, and other "
 "local-only documentation that should never be shared."
@@ -9423,25 +9448,25 @@ msgstr ""
 "ローカル専用のドキュメントのためのディレクトリです。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1404
+#: modules/configuration.org:1408
 #, no-wrap
 msgid "git-ignores-private"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1406
+#: modules/configuration.org:1410
 #, no-wrap
 msgid "\".private/\""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1409
+#: modules/configuration.org:1413
 #, no-wrap
 msgid "Scalar"
 msgstr "Scalar"
 
 #. type: paragraph
-#: modules/configuration.org:1411
+#: modules/configuration.org:1415
 msgid ""
 "[[https://git-scm.com/docs/scalar][Scalar]] optimizes git performance for "
 "large repositories. Enabled specifically for the nixpkgs repository, which "
@@ -9456,7 +9481,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph
-#: modules/configuration.org:1416
+#: modules/configuration.org:1420
 msgid ""
 "The Scalar module (=programs.git.scalar=) is a custom home-manager module "
 "defined in [[file:home-manager/git-scalar.nix][home-manager/git-scalar.nix]] "
@@ -9469,13 +9494,13 @@ msgstr ""
 "index、untracked cache、fsmonitor）を設定します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1420
+#: modules/configuration.org:1424
 #, no-wrap
 msgid "git-scalar"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1422
+#: modules/configuration.org:1426
 #, no-wrap
 msgid ""
 "scalar = {\n"
@@ -9485,13 +9510,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1428
+#: modules/configuration.org:1432
 #, no-wrap
 msgid "GitHub CLI"
 msgstr "GitHub CLI"
 
 #. type: paragraph
-#: modules/configuration.org:1430
+#: modules/configuration.org:1434
 msgid ""
 "[[https://cli.github.com/][gh]] (GitHub CLI) is enabled alongside git "
 "because it provides a credential helper ([[https://nix-community.github.io/"
@@ -9510,25 +9535,25 @@ msgstr ""
 "認証コンテキストはHTTPS経由のfetchとpushの両方をカバーします。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1436
+#: modules/configuration.org:1440
 #, no-wrap
 msgid "git-gh"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1438
+#: modules/configuration.org:1442
 #, no-wrap
 msgid "programs.gh.enable = true;"
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1441
+#: modules/configuration.org:1445
 #, no-wrap
 msgid "Delta"
 msgstr "Delta"
 
 #. type: paragraph
-#: modules/configuration.org:1443
+#: modules/configuration.org:1447
 msgid ""
 "[[https://github.com/dandavison/delta][delta]] provides syntax-highlighted "
 "diffs in the terminal with line numbers and side-by-side view support. "
@@ -9539,13 +9564,13 @@ msgstr ""
 "リーンな視覚的表現が選定理由です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1446
+#: modules/configuration.org:1450
 #, no-wrap
 msgid "git-delta"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1448
+#: modules/configuration.org:1452
 #, no-wrap
 msgid ""
 "programs.delta = {\n"
@@ -9555,13 +9580,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1454
+#: modules/configuration.org:1458
 #, no-wrap
 msgid "Difftastic"
 msgstr "Difftastic"
 
 #. type: paragraph
-#: modules/configuration.org:1456
+#: modules/configuration.org:1460
 msgid ""
 "[[https://github.com/Wilfred/difftastic][Difftastic]] is a structural diff "
 "tool that operates at the AST level rather than comparing lines. It "
@@ -9578,7 +9603,7 @@ msgstr ""
 "します。"
 
 #. type: paragraph
-#: modules/configuration.org:1462
+#: modules/configuration.org:1466
 msgid ""
 "Both difftastic and [[*Delta][delta]] are kept because they serve "
 "complementary roles: delta enhances git's built-in line diffs with syntax "
@@ -9592,13 +9617,13 @@ msgstr ""
 "[[*Lazygit][lazygit]]経由で使用します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1467
+#: modules/configuration.org:1471
 #, no-wrap
 msgid "git-difftastic"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1469
+#: modules/configuration.org:1473
 #, no-wrap
 msgid ""
 "programs.difftastic = {\n"
@@ -9607,13 +9632,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1474
+#: modules/configuration.org:1478
 #, no-wrap
 msgid "Lazygit"
 msgstr "Lazygit"
 
 #. type: paragraph
-#: modules/configuration.org:1476
+#: modules/configuration.org:1480
 msgid ""
 "[[https://github.com/jesseduffield/lazygit][Lazygit]] is a terminal UI for "
 "git. A TUI was chosen over raw git commands for interactive operations like "
@@ -9631,7 +9656,7 @@ msgstr ""
 "優位性は実際には現れず、ワークフローに不可欠な操作がいくつか欠けていました。"
 
 #. type: paragraph
-#: modules/configuration.org:1482
+#: modules/configuration.org:1486
 msgid ""
 "Performance degrades noticeably on large repositories like nixpkgs, but the "
 "ergonomics and active development make it a trusted part of the workflow "
@@ -9642,13 +9667,13 @@ msgstr ""
 "部となっています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1485
+#: modules/configuration.org:1489
 #, no-wrap
 msgid "git-lazygit"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1487
+#: modules/configuration.org:1491
 #, no-wrap
 msgid ""
 "programs.lazygit = {\n"
@@ -9658,7 +9683,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1492
+#: modules/configuration.org:1496
 #, no-wrap
 msgid ""
 "    <<lazygit-git>>\n"
@@ -9667,26 +9692,26 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1497
+#: modules/configuration.org:1501
 #, no-wrap
 msgid "GUI"
 msgstr "GUI"
 
 #. type: paragraph
-#: modules/configuration.org:1499
+#: modules/configuration.org:1503
 msgid "Enable Nerd Font icons in the lazygit interface for visual clarity."
 msgstr ""
 "視認性向上のため、lazygitのインターフェースでNerd Fontアイコンを有効にしま"
 "す。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1501
+#: modules/configuration.org:1505
 #, no-wrap
 msgid "lazygit-gui"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1503
+#: modules/configuration.org:1507
 #, no-wrap
 msgid ""
 "gui = {\n"
@@ -9695,13 +9720,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1508
+#: modules/configuration.org:1512
 #, no-wrap
 msgid "Git Integration"
 msgstr "Git連携"
 
 #. type: paragraph
-#: modules/configuration.org:1510
+#: modules/configuration.org:1514
 msgid ""
 "=overrideGpg = true= tells lazygit to run git commands inline instead of "
 "spawning a subprocess for GPG/SSH signing. By default, lazygit defers to a "
@@ -9726,7 +9751,7 @@ msgstr ""
 "ンプトが不要になり、すべてのリベース操作が正常に動作します。"
 
 #. type: paragraph
-#: modules/configuration.org:1519
+#: modules/configuration.org:1523
 msgid ""
 "The pager configuration integrates both [[*Delta][delta]] and [[*Difftastic]"
 "[difftastic]] into lazygit's diff views.  Delta provides syntax-highlighted "
@@ -9741,13 +9766,13 @@ msgstr ""
 "用できます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1524
+#: modules/configuration.org:1528
 #, no-wrap
 msgid "lazygit-git"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1526
+#: modules/configuration.org:1530
 #, no-wrap
 msgid ""
 "git = {\n"
@@ -9765,13 +9790,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1540
+#: modules/configuration.org:1544
 #, no-wrap
 msgid "Fish Abbreviations"
 msgstr "Fishの略語"
 
 #. type: paragraph
-#: modules/configuration.org:1542
+#: modules/configuration.org:1546
 msgid ""
 "Shell abbreviations for frequent git operations. Abbreviations (not aliases) "
 "are used because fish expands them inline before execution, making the "
@@ -9782,13 +9807,13 @@ msgstr ""
 "前の修正も可能になるためです。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1546
+#: modules/configuration.org:1550
 #, no-wrap
 msgid "git-fish-abbreviations"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1548
+#: modules/configuration.org:1552
 #, no-wrap
 msgid ""
 "programs.fish.shellAbbrs = {\n"
@@ -9802,13 +9827,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1558
+#: modules/configuration.org:1562
 #, no-wrap
 msgid "Push"
 msgstr "Push"
 
 #. type: paragraph
-#: modules/configuration.org:1560
+#: modules/configuration.org:1564
 msgid ""
 "Force push with lease — safer than =--force= as it prevents overwriting "
 "remote changes not yet fetched."
@@ -9817,25 +9842,25 @@ msgstr ""
 "ぐため、=--force= よりも安全です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1563
+#: modules/configuration.org:1567
 #, no-wrap
 msgid "git-abbr-push"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1565
+#: modules/configuration.org:1569
 #, no-wrap
 msgid "gpf = \"git push --force-with-lease\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1568
+#: modules/configuration.org:1572
 #, no-wrap
 msgid "Pull"
 msgstr "Pull"
 
 #. type: paragraph
-#: modules/configuration.org:1570
+#: modules/configuration.org:1574
 msgid ""
 "=gpm= pulls from the remote's default branch, dynamically detected via =git "
 "remote show= rather than hardcoding =main= or =master=. This handles "
@@ -9846,7 +9871,7 @@ msgstr ""
 "=master= や他のブランチ命名規約を使用するリポジトリにも対応できます。"
 
 #. type: paragraph
-#: modules/configuration.org:1574
+#: modules/configuration.org:1578
 msgid ""
 "=gpu= pulls from upstream — used in fork workflows to sync with the original "
 "repository."
@@ -9855,13 +9880,13 @@ msgstr ""
 "と同期するために使用されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1576
+#: modules/configuration.org:1580
 #, no-wrap
 msgid "git-abbr-pull"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1578
+#: modules/configuration.org:1582
 #, no-wrap
 msgid ""
 "gpm = \"git pull (git remote show origin | sed -n '/HEAD branch/s/.*: //p')\";\n"
@@ -9869,13 +9894,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1582
+#: modules/configuration.org:1586
 #, no-wrap
 msgid "Commit"
 msgstr "Commit"
 
 #. type: paragraph
-#: modules/configuration.org:1584
+#: modules/configuration.org:1588
 msgid ""
 "=gci= creates a commit. The trailing space allows directly appending =-m "
 "\"message\"=."
@@ -9884,7 +9909,7 @@ msgstr ""
 "加できます。"
 
 #. type: paragraph
-#: modules/configuration.org:1586
+#: modules/configuration.org:1590
 msgid ""
 "=gca= amends the last commit, frequently used during interactive rebase "
 "workflows."
@@ -9893,13 +9918,13 @@ msgstr ""
 "繁に使用されます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1588
+#: modules/configuration.org:1592
 #, no-wrap
 msgid "git-abbr-commit"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1590
+#: modules/configuration.org:1594
 #, no-wrap
 msgid ""
 "gci = \"git commit \";\n"
@@ -9907,37 +9932,37 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1594
+#: modules/configuration.org:1598
 #, no-wrap
 msgid "Status"
 msgstr "Status"
 
 #. type: keyword NAME
-#: modules/configuration.org:1596
+#: modules/configuration.org:1600
 #, no-wrap
 msgid "git-abbr-status"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1598
+#: modules/configuration.org:1602
 #, no-wrap
 msgid "gs = \"git status\";"
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1601
+#: modules/configuration.org:1605
 #, no-wrap
 msgid "Stash"
 msgstr "Stash"
 
 #. type: keyword NAME
-#: modules/configuration.org:1603
+#: modules/configuration.org:1607
 #, no-wrap
 msgid "git-abbr-stash"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1605
+#: modules/configuration.org:1609
 #, no-wrap
 msgid ""
 "gst = \"git stash\";\n"
@@ -9945,19 +9970,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1609
+#: modules/configuration.org:1613
 #, no-wrap
 msgid "Switch"
 msgstr "Switch"
 
 #. type: keyword NAME
-#: modules/configuration.org:1611
+#: modules/configuration.org:1615
 #, no-wrap
 msgid "git-abbr-switch"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1613
+#: modules/configuration.org:1617
 #, no-wrap
 msgid ""
 "gsw = \"git switch\";\n"
@@ -9965,19 +9990,19 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: modules/configuration.org:1617
+#: modules/configuration.org:1621
 #, no-wrap
 msgid "Browser"
 msgstr "ブラウザー"
 
 #. type: heading **
-#: modules/configuration.org:1619
+#: modules/configuration.org:1623
 #, no-wrap
 msgid "Zen Browser"
 msgstr "Zen Browser"
 
 #. type: paragraph
-#: modules/configuration.org:1621
+#: modules/configuration.org:1625
 msgid ""
 "[[https://zen-browser.app/][Zen Browser]] is a Firefox-based browser with a "
 "focus on privacy and customization.  Firefox derivatives were preferred over "
@@ -9993,7 +10018,7 @@ msgstr ""
 "ChromiumベースのブラウザよりFirefox派生が選ばれました。"
 
 #. type: paragraph
-#: modules/configuration.org:1626
+#: modules/configuration.org:1630
 msgid ""
 "Zen Browser was chosen over vanilla Firefox for its improved UI/UX while "
 "retaining full Firefox compatibility — extensions, search engines, and "
@@ -10004,7 +10029,7 @@ msgstr ""
 "動作します。"
 
 #. type: paragraph in src
-#: modules/configuration.org:1635
+#: modules/configuration.org:1639
 #, no-wrap
 msgid ""
 "{\n"
@@ -10022,7 +10047,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1648
+#: modules/configuration.org:1652
 #, no-wrap
 msgid ""
 "options.my.programs.zen-browser = {\n"
@@ -10031,7 +10056,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1652
+#: modules/configuration.org:1656
 #, no-wrap
 msgid ""
 "config = lib.mkIf cfg.enable {\n"
@@ -10042,13 +10067,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1658
+#: modules/configuration.org:1662
 #, no-wrap
 msgid "<<zen-browser-search>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1660
+#: modules/configuration.org:1664
 #, no-wrap
 msgid ""
 "        <<zen-browser-extensions>>\n"
@@ -10059,13 +10084,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1667
+#: modules/configuration.org:1671
 #, no-wrap
 msgid "Settings"
 msgstr "設定"
 
 #. type: paragraph
-#: modules/configuration.org:1669
+#: modules/configuration.org:1673
 msgid ""
 "Auto-install extensions without user prompts. By default, Firefox shows a "
 "confirmation dialog for each extension installed via the profile. Setting "
@@ -10081,13 +10106,13 @@ msgstr ""
 "初回起動時にすべての拡張機能について手動承認が必要になります。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1675
+#: modules/configuration.org:1679
 #, no-wrap
 msgid "zen-browser-settings"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1677
+#: modules/configuration.org:1681
 #, no-wrap
 msgid ""
 "settings = {\n"
@@ -10096,13 +10121,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1682
+#: modules/configuration.org:1686
 #, no-wrap
 msgid "Search Engines"
 msgstr "検索エンジン"
 
 #. type: paragraph
-#: modules/configuration.org:1684
+#: modules/configuration.org:1688
 msgid ""
 "Custom search engines for quick access to development-related package "
 "registries and documentation. Each engine is assigned a short alias (e.g., "
@@ -10114,13 +10139,13 @@ msgstr ""
 "おり、アドレスバーで使用でき、各サイトに手動で移動する必要がなくなります。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1688
+#: modules/configuration.org:1692
 #, no-wrap
 msgid "zen-browser-search"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1690
+#: modules/configuration.org:1694
 #, no-wrap
 msgid ""
 "search = {\n"
@@ -10130,31 +10155,31 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1695
+#: modules/configuration.org:1699
 #, no-wrap
 msgid "<<zen-browser-search-engine-nixos-wiki>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1697
+#: modules/configuration.org:1701
 #, no-wrap
 msgid "<<zen-browser-search-engine-noogle>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1699
+#: modules/configuration.org:1703
 #, no-wrap
 msgid "<<zen-browser-search-engine-crates-io>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1701
+#: modules/configuration.org:1705
 #, no-wrap
 msgid "<<zen-browser-search-engine-npm>>"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1703
+#: modules/configuration.org:1707
 #, no-wrap
 msgid ""
 "    <<zen-browser-search-engine-pypi>>\n"
@@ -10163,13 +10188,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1708
+#: modules/configuration.org:1712
 #, no-wrap
 msgid "Nix Packages"
 msgstr "Nixパッケージ"
 
 #. type: paragraph
-#: modules/configuration.org:1710
+#: modules/configuration.org:1714
 msgid ""
 "Search the official NixOS/nixpkgs repository. Uses =nixos-icons= from "
 "nixpkgs for the icon to avoid depending on an external URL that could change "
@@ -10179,13 +10204,13 @@ msgstr ""
 "部URLに依存しないよう、アイコンにはnixpkgsの=nixos-icons= を使用しています。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1713
+#: modules/configuration.org:1717
 #, no-wrap
 msgid "zen-browser-search-engine-nix-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1715
+#: modules/configuration.org:1719
 #, no-wrap
 msgid ""
 "nix-packages = {\n"
@@ -10208,7 +10233,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1733
+#: modules/configuration.org:1737
 #, no-wrap
 msgid ""
 "  icon = \"${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg\";\n"
@@ -10217,13 +10242,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1738
+#: modules/configuration.org:1742
 #, no-wrap
 msgid "NixOS Wiki"
 msgstr "NixOS Wiki"
 
 #. type: paragraph
-#: modules/configuration.org:1740
+#: modules/configuration.org:1744
 msgid ""
 "Search the NixOS community wiki for configuration examples and "
 "troubleshooting guides."
@@ -10231,13 +10256,13 @@ msgstr ""
 "NixOSコミュニティwikiで設定例やトラブルシューティングガイドを検索します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1742
+#: modules/configuration.org:1746
 #, no-wrap
 msgid "zen-browser-search-engine-nixos-wiki"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1744
+#: modules/configuration.org:1748
 #, no-wrap
 msgid ""
 "nixos-wiki = {\n"
@@ -10249,13 +10274,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1752
+#: modules/configuration.org:1756
 #, no-wrap
 msgid "noogle"
 msgstr "noogle"
 
 #. type: paragraph
-#: modules/configuration.org:1754
+#: modules/configuration.org:1758
 msgid ""
 "[[https://noogle.dev/][noogle]] is a Nix function search engine — the "
 "equivalent of Hoogle for Haskell.  Useful for discovering library functions "
@@ -10266,13 +10291,13 @@ msgstr ""
 "るのに便利です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1757
+#: modules/configuration.org:1761
 #, no-wrap
 msgid "zen-browser-search-engine-noogle"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1759
+#: modules/configuration.org:1763
 #, no-wrap
 msgid ""
 "noogle = {\n"
@@ -10284,25 +10309,25 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1767
+#: modules/configuration.org:1771
 #, no-wrap
 msgid "crates.io"
 msgstr "crates.io"
 
 #. type: paragraph
-#: modules/configuration.org:1769
+#: modules/configuration.org:1773
 msgid ""
 "Search the Rust package registry for crate discovery and version information."
 msgstr "Rustパッケージレジストリでcrateの検索とバージョン情報を調べます。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1771
+#: modules/configuration.org:1775
 #, no-wrap
 msgid "zen-browser-search-engine-crates-io"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1773
+#: modules/configuration.org:1777
 #, no-wrap
 msgid ""
 "crates-io = {\n"
@@ -10314,24 +10339,24 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1781
+#: modules/configuration.org:1785
 #, no-wrap
 msgid "npm"
 msgstr "npm"
 
 #. type: paragraph
-#: modules/configuration.org:1783
+#: modules/configuration.org:1787
 msgid "Search the npm registry for JavaScript/TypeScript package discovery."
 msgstr "npmレジストリでJavaScript/TypeScriptパッケージを検索します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1785
+#: modules/configuration.org:1789
 #, no-wrap
 msgid "zen-browser-search-engine-npm"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1787
+#: modules/configuration.org:1791
 #, no-wrap
 msgid ""
 "npm = {\n"
@@ -10343,24 +10368,24 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: modules/configuration.org:1795
+#: modules/configuration.org:1799
 #, no-wrap
 msgid "PyPI"
 msgstr "PyPI"
 
 #. type: paragraph
-#: modules/configuration.org:1797
+#: modules/configuration.org:1801
 msgid "Search the Python Package Index for Python package discovery."
 msgstr "Python Package IndexでPythonパッケージを検索します。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1799
+#: modules/configuration.org:1803
 #, no-wrap
 msgid "zen-browser-search-engine-pypi"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1801
+#: modules/configuration.org:1805
 #, no-wrap
 msgid ""
 "pypi = {\n"
@@ -10372,13 +10397,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:1809
+#: modules/configuration.org:1813
 #, no-wrap
 msgid "Extensions"
 msgstr "拡張機能"
 
 #. type: paragraph
-#: modules/configuration.org:1811
+#: modules/configuration.org:1815
 msgid ""
 "Browser extensions managed declaratively. Extensions are sourced from two "
 "overlay-provided sets: =firefox-addons= (from the NUR firefox-addons "
@@ -10390,13 +10415,13 @@ msgstr ""
 "と =my-firefox-addons=（アップストリームにないカスタムの追加）です。"
 
 #. type: keyword NAME
-#: modules/configuration.org:1815
+#: modules/configuration.org:1819
 #, no-wrap
 msgid "zen-browser-extensions"
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1817
+#: modules/configuration.org:1821
 #, no-wrap
 msgid ""
 "extensions = {\n"
@@ -10421,20 +10446,20 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1840
+#: modules/configuration.org:1844
 #, no-wrap
 msgid "Neovim"
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1842
+#: modules/configuration.org:1846
 msgid ""
 "Neovim is the editor I spend the most time in, primarily for coding — though "
 "the gravitational pull of =org-mode= is slowly dragging me over to Emacs."
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1846
+#: modules/configuration.org:1850
 msgid ""
 "Everything Neovim-related lives under =flake/features/neovim/=: the wrapped "
 "derivation (=package.nix=) and the lua configuration. The flake-parts module "
@@ -10442,7 +10467,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 1.
-#: modules/configuration.org:1852
+#: modules/configuration.org:1856
 #, no-wrap
 msgid ""
 "=perSystem.packages.neovim= makes =nix run .#neovim= work on every\n"
@@ -10450,7 +10475,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 2.
-#: modules/configuration.org:1855
+#: modules/configuration.org:1859
 #, no-wrap
 msgid ""
 "=flake.homeManagerModules.neovim= lets a home-manager config opt in\n"
@@ -10459,7 +10484,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1857
+#: modules/configuration.org:1861
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -10476,7 +10501,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1869
+#: modules/configuration.org:1873
 #, no-wrap
 msgid ""
 "  config = lib.mkIf config.my.programs.neovim.enable {\n"
@@ -10490,7 +10515,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1878
+#: modules/configuration.org:1882
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -10502,13 +10527,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: modules/configuration.org:1886
+#: modules/configuration.org:1890
 #, no-wrap
 msgid "Emacs"
 msgstr "Emacs"
 
 #. type: paragraph
-#: modules/configuration.org:1888
+#: modules/configuration.org:1892
 msgid ""
 "Emacs has been my second-most-used editor since early 2026. The draw is =org-"
 "mode= — the workflows built around =org-capture= and =org-agenda= are slowly "
@@ -10518,14 +10543,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: modules/configuration.org:1894
+#: modules/configuration.org:1898
 msgid ""
 "The feature lives alongside Neovim under =flake/features/emacs/= and pulls "
 "the same double duty:"
 msgstr ""
 
 #. type: plain list 1.
-#: modules/configuration.org:1901
+#: modules/configuration.org:1905
 #, no-wrap
 msgid ""
 "=perSystem.packages.emacs= exposes a wrapped emacs as a flake\n"
@@ -10535,7 +10560,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list 2.
-#: modules/configuration.org:1905
+#: modules/configuration.org:1909
 #, no-wrap
 msgid ""
 "=flake.homeManagerModules.emacs= adds =my.programs.emacs.enable= for\n"
@@ -10545,7 +10570,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1908
+#: modules/configuration.org:1912
 #, no-wrap
 msgid ""
 "{ lib, inputs, ... }:\n"
@@ -10554,7 +10579,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1912
+#: modules/configuration.org:1916
 #, no-wrap
 msgid ""
 "emacsUnwrapped =\n"
@@ -10566,7 +10591,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1922
+#: modules/configuration.org:1926
 #, no-wrap
 msgid ""
 "tangle =\n"
@@ -10586,7 +10611,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1937
+#: modules/configuration.org:1941
 #, no-wrap
 msgid ""
 "tangleEl =\n"
@@ -10601,7 +10626,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1947
+#: modules/configuration.org:1951
 #, no-wrap
 msgid ""
 "  mkEmacs =\n"
@@ -10627,7 +10652,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1968
+#: modules/configuration.org:1972
 #, no-wrap
 msgid ""
 "config = lib.mkIf config.my.programs.emacs.enable {\n"
@@ -10638,7 +10663,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1974
+#: modules/configuration.org:1978
 #, no-wrap
 msgid ""
 "services.emacs = {\n"
@@ -10648,7 +10673,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1979
+#: modules/configuration.org:1983
 #, no-wrap
 msgid ""
 "xdg.configFile.\"emacs/init.el\".source = tangleEl pkgs ./init.org;\n"
@@ -10657,7 +10682,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1983
+#: modules/configuration.org:1987
 #, no-wrap
 msgid ""
 "    home.shellAliases = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {\n"
@@ -10668,7 +10693,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1989
+#: modules/configuration.org:1993
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -10680,7 +10705,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: modules/configuration.org:1998
+#: modules/configuration.org:2002
 #, no-wrap
 msgid ""
 "{\n"
@@ -10737,30 +10762,86 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: modules/configuration.org:2054
+#: modules/configuration.org:2058
 #, no-wrap
 msgid "early-init.org"
 msgstr "early-init.org"
 
 #. type: keyword INCLUDE
-#: modules/configuration.org:2055
+#: modules/configuration.org:2059
 #, fuzzy, no-wrap
 #| msgid "\"./applications/emacs/early-init.org\""
 msgid "\"./flake/features/emacs/early-init.org\""
 msgstr "\"./applications/emacs/early-init.ja.org\""
 
 #. type: heading ***
-#: modules/configuration.org:2056
+#: modules/configuration.org:2060
 #, no-wrap
 msgid "init.org"
 msgstr "init.org"
 
 #. type: keyword INCLUDE
-#: modules/configuration.org:2057
+#: modules/configuration.org:2061
 #, fuzzy, no-wrap
 #| msgid "\"./applications/emacs/init.org\""
 msgid "\"./flake/features/emacs/init.org\""
 msgstr "\"./applications/emacs/init.ja.org\""
+
+#~ msgid ""
+#~ "Self-hosted Attic cache containing outputs from this flake. Packages not "
+#~ "available in the official =cache.nixos.org= or =nix-community.cachix.org= "
+#~ "are built on GitHub Actions and pushed here. Listed in both the flake's "
+#~ "=nixConfig= and the system =nix.settings= because comin rebuilds non-"
+#~ "interactively and would otherwise ignore the flake-provided substituter "
+#~ "without =accept-flake-config=. See =systems/nixos/services/attic= for the "
+#~ "server runbook."
+#~ msgstr ""
+#~ "このフレークの成果物を格納する自前ホストの Attic キャッシュです。公式の "
+#~ "=cache.nixos.org= や =nix-community.cachix.org= に無いパッケージは GitHub "
+#~ "Actions でビルドされ、ここに push されます。フレークの =nixConfig= とシス"
+#~ "テムの =nix.settings= の両方に記載しているのは、comin が非対話でリビルドす"
+#~ "るため、=accept-flake-config= が無いとフレーク側で指定した substituter が"
+#~ "無視されてしまうからです。サーバーのセットアップ手順は =systems/nixos/"
+#~ "services/attic= を参照してください。"
+
+#, no-wrap
+#~ msgid "natsukium.cachix.org"
+#~ msgstr "natsukium.cachix.org"
+
+#~ msgid ""
+#~ "Personal Cachix cache. It previously held this flake's CI outputs, but "
+#~ "the dotfiles closures outgrew Cachix's storage limits, so CI now pushes "
+#~ "to the self-hosted =cache.natsukium.com= instead. Kept here only as a "
+#~ "substituter so paths built before the switch still resolve; Cachix itself "
+#~ "remains in use for other projects."
+#~ msgstr ""
+#~ "個人用の Cachix キャッシュです。以前はこのフレークの CI 成果物を格納してい"
+#~ "ましたが、dotfiles のクロージャが Cachix のストレージ上限に収まらなくなっ"
+#~ "たため、CI は現在、自前ホストの =cache.natsukium.com= に push しています。"
+#~ "切り替え前にビルドされたパスを引き続き解決できるよう substituter としての"
+#~ "み残しており、Cachix 自体は他のプロジェクトで引き続き使用しています。"
+
+#~ msgid ""
+#~ "Legacy personal cache, kept only as a substituter so paths built before "
+#~ "the switch to Attic still resolve. CI no longer pushes here; remove once "
+#~ "Attic has accumulated enough paths."
+#~ msgstr ""
+#~ "以前から使っている個人用キャッシュで、Attic への切り替え前にビルドされたパ"
+#~ "スを引き続き解決できるよう、substituter としてのみ残しています。CI はここ"
+#~ "へ push しなくなっており、Attic に十分なパスが溜まったら削除します。"
+
+#~ msgid ""
+#~ "Two binary caches are configured: =natsukium= holds pre-built artifacts "
+#~ "for this dotfiles repository (CI-built system closures and custom "
+#~ "packages), and =nix-community= provides caches for community projects "
+#~ "including NVIDIA/CUDA packages and other nix-community-maintained "
+#~ "derivations."
+#~ msgstr ""
+#~ "2つのバイナリキャッシュが設定されています。=natsukium= はこのdotfilesリポ"
+#~ "ジトリのビルド済みアーティファクト（CIでビルドされたシステムクロージャーや"
+#~ "カスタムパッケージ）を保持し、=nix-community= はNVIDIA/CUDAパッケージやそ"
+#~ "の他のnix-communityが管理するderivationを含むコミュニティプロジェクトの"
+#~ "キャッシュを提供します。"
 
 #, fuzzy, no-wrap
 #~| msgid ""

--- a/systems/nixos/services/attic/default.nix
+++ b/systems/nixos/services/attic/default.nix
@@ -3,16 +3,33 @@ let
   atticdPort = "8081";
 in
 {
-  # to create the token, run the following command
-  # sudo atticd-atticadm make-token \
-  #   --validity "10 years" \
-  #   --sub "nixpkgs" \
-  #   --pull "nixpkgs" \
-  #   --push "nixpkgs" \
-  #   --create-cache "nixpkgs" \
-  #   --configure-cache "nixpkgs" \
-  #   --configure-cache-retention "nixpkgs" \
-  #   --destroy-cache "nixpkgs"
+  # Setup runbook for the `dotfiles` cache that CI pushes to.
+  #
+  # Tokens are split by privilege so the long-lived secret stored on GitHub
+  # can only push/pull, never reconfigure or destroy a cache. atticd-atticadm
+  # must run on the host (it reads the server signing key from the env file).
+  #
+  # 1. Bootstrap token (full privileges, run locally once, do NOT store):
+  #    sudo atticd-atticadm make-token \
+  #      --validity "1 hour" --sub "admin-bootstrap" \
+  #      --pull "dotfiles" --push "dotfiles" \
+  #      --create-cache "dotfiles" --configure-cache "dotfiles"
+  #
+  # 2. Create the cache and make it public so machines pull anonymously
+  #    (only substituter URL + trusted-public-key needed, no per-host login):
+  #    attic login natsukium https://cache.natsukium.com <bootstrap-token>
+  #    attic cache create dotfiles
+  #    attic cache configure dotfiles --public
+  #
+  # 3. Read the public key and add it to nix.settings.trusted-public-keys in
+  #    modules/configuration.org (Binary Caches section):
+  #    attic cache info dotfiles   # -> dotfiles:....=
+  #
+  # 4. CI token (push/pull only, least privilege) -> GitHub ATTIC_TOKEN secret:
+  #    sudo atticd-atticadm make-token \
+  #      --validity "1 year" --sub "github-ci-dotfiles" \
+  #      --pull "dotfiles" --push "dotfiles"
+  #    gh secret set ATTIC_TOKEN   # paste the token above
 
   services.atticd = {
     enable = true;


### PR DESCRIPTION
Cachix's free storage is limited and the cache lives on a third party.
Switch CI to push to our own Attic instance (cache.natsukium.com, backed
by R2) so cache hosting stays under our control without storage caps.