### PR TITLE
feat(infra): provision R2 bucket and DNS for the niks3 cache

### DIFF
--- a/infra/global/domains/natsukium-com/main.tf
+++ b/infra/global/domains/natsukium-com/main.tf
@@ -41,6 +41,13 @@ locals {
       proxied = true
       type    = "CNAME"
     }
+    niks3 = {
+      # write path: presigned-URL minting only. Reads go to nix-cache via R2.
+      content = "acfc103f-c6b4-4cef-8269-e1985b80e1ac.cfargotunnel.com"
+      name    = "niks3.natsukium.com"
+      proxied = true
+      type    = "CNAME"
+    }
     forgejo = {
       content = "acfc103f-c6b4-4cef-8269-e1985b80e1ac.cfargotunnel.com"
       name    = "git.natsukium.com"
@@ -99,4 +106,22 @@ resource "cloudflare_workers_route" "matrix_well_known" {
   zone_id = local.zone_id
   pattern = "natsukium.com/.well-known/matrix/*"
   script  = cloudflare_workers_script.matrix_well_known.script_name
+}
+
+# Separate from the Attic bucket: niks3's standard binary-cache layout is
+# incompatible with Attic's chunked store.
+resource "cloudflare_r2_bucket" "nix_cache_niks3" {
+  account_id = local.cloudflare_account_id
+  name       = "nix-cache-niks3"
+}
+
+# Public read path: clients pull straight from R2 (CDN-cached), bypassing the
+# tunnel. Cloudflare manages this DNS record itself, hence not in local.records.
+resource "cloudflare_r2_custom_domain" "nix_cache_niks3" {
+  account_id  = local.cloudflare_account_id
+  zone_id     = local.zone_id
+  bucket_name = cloudflare_r2_bucket.nix_cache_niks3.name
+  domain      = "nix-cache.natsukium.com"
+  enabled     = true
+  min_tls     = "1.2"
 }


### PR DESCRIPTION
## What

Provisions the Cloudflare R2 storage and DNS that the upcoming **niks3** binary cache depends on. This is split out ahead of the NixOS service change because Terraform applies on push to `main`, so these resources must exist *before* manyara is switched over to niks3.

## Changes (`infra/global/domains/natsukium-com`)

- **`cloudflare_r2_bucket.nix_cache_niks3`** (`nix-cache-niks3`) — a dedicated bucket, separate from the Attic one, because niks3 uses the standard binary-cache layout which is incompatible with Attic's chunked store.
- **`cloudflare_r2_custom_domain.nix_cache_niks3`** (`nix-cache.natsukium.com`) — the public **read** path. Clients pull directly from R2 (CDN-cached) without touching the tunnel or the niks3 server. Cloudflare manages this DNS record itself, so it is intentionally not in `local.records`.
- **`niks3.natsukium.com` CNAME** to manyara's tunnel — the **write** path, used only for presigned-URL minting; NAR bodies bypass it and go straight to R2.

## Why niks3 / why now

The current Attic cache sits behind a cloudflared tunnel, which proxies every NAR upload through the server and hits Cloudflare's 100 MiB request-body limit — large derivations cannot be cached at all. niks3 hands clients presigned URLs so uploads go straight to R2, keeping only small API calls on the tunnel.

## Follow-up (not in this PR)

After this merges and `terraform apply` runs:
1. Create an R2 API token (object read/write on `nix-cache-niks3`) in the Cloudflare dashboard — the TF provider doesn't expose R2 tokens.
2. Generate the niks3 signing key + API token, store them in sops.
3. Land the NixOS service + CI changes (separate PR) and deploy manyara.

Attic stays in place until the niks3 cache is warm.