### PR TITLE
feat(monitoring): Claude Code telemetry in Grafana

### DIFF
--- a/hosts/nixos/manyara/default.nix
+++ b/hosts/nixos/manyara/default.nix
@@ -30,6 +30,7 @@
   my.services.grafana.enable = true;
   my.services.prometheus.enable = true;
   my.services.loki.enable = true;
+  my.services.tempo.enable = true;
   my.services.alertmanager.enable = true;
   my.services.blackbox.enable = true;
   my.services.postgres-exporter.enable = true;

--- a/modules/features/coding-agents/claude-code/default.nix
+++ b/modules/features/coding-agents/claude-code/default.nix
@@ -143,7 +143,29 @@
 
             env = {
               CLAUDE_CODE_ENABLE_TELEMETRY = "1";
-              OTEL_METRICS_EXPORTER = "prometheus";
+              # Traces are still beta and gated behind this flag.
+              CLAUDE_CODE_ENHANCED_TELEMETRY_BETA = "1";
+
+              # Push all three signals over OTLP to the local Alloy receiver
+              # (my.services.otel-collector) rather than exposing a Prometheus
+              # endpoint: a CLI session is too short-lived to be scraped.
+              OTEL_METRICS_EXPORTER = "otlp";
+              OTEL_LOGS_EXPORTER = "otlp";
+              OTEL_TRACES_EXPORTER = "otlp";
+              OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+              OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317";
+              # Prometheus stores cumulative counters, so emit cumulative to skip
+              # a delta-to-cumulative conversion stage in Alloy.
+              OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "cumulative";
+              OTEL_RESOURCE_ATTRIBUTES = "service.name=claude-code";
+
+              # Personal environment: capture full prompt/response and tool
+              # detail so traces and event logs are actually inspectable.
+              OTEL_LOG_USER_PROMPTS = "1";
+              OTEL_LOG_ASSISTANT_RESPONSES = "1";
+              OTEL_LOG_TOOL_DETAILS = "1";
+              OTEL_LOG_TOOL_CONTENT = "1";
+
               CLAUDE_CODE_AUTO_COMPACT_WINDOW = "450000";
             };
           };

--- a/modules/features/grafana/dashboards/claude-code.json
+++ b/modules/features/grafana/dashboards/claude-code.json
@@ -1,0 +1,799 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": ["claude-code", "llm", "otel"],
+  "templating": {
+    "list": [
+      {
+        "name": "host",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(claude_code_session_count, host)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(claude_code_session_count, host)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Claude Code",
+  "uid": "claude-code-overview",
+  "weekStart": "",
+  "panels": [
+    {
+      "id": 100,
+      "title": "Overview",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 1,
+      "title": "Cost",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_cost_usage{host=~\"$host\"}[$__range]))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 2,
+      "title": "Cost / session",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "description": "Average spend per CLI session over the selected range.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_cost_usage{host=~\"$host\"}[$__range])) / clamp_min(sum(increase(claude_code_session_count{host=~\"$host\"}[$__range])), 1)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 3,
+      "title": "Tokens",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "blue" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_token_usage{host=~\"$host\"}[$__range]))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 4,
+      "title": "Cache hit rate",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "description": "Cached prompt tokens as a share of all prompt-side tokens (cacheRead / (cacheRead + cacheCreation + input)).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_token_usage{type=\"cacheRead\",host=~\"$host\"}[$__range])) / clamp_min(sum(increase(claude_code_token_usage{type=~\"cacheRead|cacheCreation|input\",host=~\"$host\"}[$__range])), 1)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 5,
+      "title": "Sessions",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "fixed", "fixedColor": "purple" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_session_count{host=~\"$host\"}[$__range]))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 6,
+      "title": "Active time",
+      "type": "stat",
+      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_active_time_total{host=~\"$host\"}[$__range]))",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 101,
+      "title": "Cost & tokens",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 7,
+      "title": "Cost over time by model",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
+      "interval": "1m",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "axisPlacement": "auto",
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum"],
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (model) (increase(claude_code_cost_usage{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 8,
+      "title": "Token usage by type",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
+      "interval": "1m",
+      "description": "input / output / cacheRead / cacheCreation.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "axisPlacement": "auto",
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum"],
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (type) (increase(claude_code_token_usage{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 9,
+      "title": "Cost share by model",
+      "type": "piechart",
+      "gridPos": { "x": 0, "y": 14, "w": 8, "h": 8 },
+      "fieldConfig": {
+        "defaults": { "unit": "currencyUSD", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "pieType": "donut",
+        "tooltip": { "mode": "single", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"],
+          "showLegend": true
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (model) (increase(claude_code_cost_usage{host=~\"$host\"}[$__range]))",
+          "instant": true,
+          "range": false,
+          "refId": "A",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 10,
+      "title": "Tokens by model",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 14, "w": 8, "h": 8 },
+      "interval": "1m",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [], "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (model) (increase(claude_code_token_usage{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 11,
+      "title": "Cache read ratio over time",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 14, "w": 8, "h": 8 },
+      "interval": "1m",
+      "description": "cacheRead / (cacheRead + cacheCreation + input).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "showPoints": "never",
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [],
+          "showLegend": false
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(claude_code_token_usage{type=\"cacheRead\",host=~\"$host\"}[$__rate_interval])) / clamp_min(sum(rate(claude_code_token_usage{type=~\"cacheRead|cacheCreation|input\",host=~\"$host\"}[$__rate_interval])), 1)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "cache read ratio"
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "title": "Activity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 12,
+      "title": "Lines of code changed",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 23, "w": 8, "h": 8 },
+      "interval": "1m",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 70,
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "none", "group": "A" },
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "added" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "removed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [], "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (type) (increase(claude_code_lines_of_code_count{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 13,
+      "title": "Commits & PRs",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 23, "w": 8, "h": 8 },
+      "interval": "1m",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 70,
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "none", "group": "A" },
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [], "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_commit_count{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "commits"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(increase(claude_code_pull_request_count{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "pull requests"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "id": 14,
+      "title": "Edit tool decisions",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 23, "w": 8, "h": 8 },
+      "interval": "1m",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 70,
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "accept" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "reject" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [], "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum by (decision) (increase(claude_code_code_edit_tool_decision{host=~\"$host\"}[$__rate_interval]))",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{decision}}"
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "title": "Events",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 31, "w": 24, "h": 1 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "id": 15,
+      "title": "Event volume by type",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 32, "w": 24, "h": 6 },
+      "description": "Counts of Claude Code OTEL events (user_prompt, api_request, tool_result, api_error, ...).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "spanNulls": false,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" },
+            "scaleDistribution": { "type": "linear" }
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["sum"],
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "sum by (event_name) (count_over_time({service_name=\"claude-code\"} | event_name != `` [$__auto]))",
+          "queryType": "range",
+          "refId": "A",
+          "legendFormat": "{{event_name}}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "id": 16,
+      "title": "All events",
+      "type": "logs",
+      "gridPos": { "x": 0, "y": 38, "w": 14, "h": 11 },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "{service_name=\"claude-code\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "id": 17,
+      "title": "Errors & refusals",
+      "type": "logs",
+      "gridPos": { "x": 14, "y": 38, "w": 10, "h": 11 },
+      "description": "api_error, api_refusal and internal_error events only.",
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "expr": "{service_name=\"claude-code\"} | event_name =~ `api_error|api_refusal|internal_error`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 104,
+      "title": "Traces",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 49, "w": 24, "h": 1 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "id": 18,
+      "title": "Recent interactions",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 50, "w": 24, "h": 12 },
+      "description": "Root spans (claude_code.interaction). Click a trace to open it; a span links back to the matching Loki events.",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "options": { "showHeader": true },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceqlSearch",
+          "tableType": "traces",
+          "limit": 50,
+          "filters": [
+            {
+              "id": "service-name",
+              "tag": "service.name",
+              "operator": "=",
+              "scope": "resource",
+              "value": ["claude-code"],
+              "valueType": "string"
+            }
+          ],
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/features/grafana/default.nix
+++ b/modules/features/grafana/default.nix
@@ -36,6 +36,34 @@
                 type = "loki";
                 uid = "loki";
                 url = "http://127.0.0.1:${toString config.services.loki.configuration.server.http_listen_port}";
+                # Claude Code events carry a trace_id in structured metadata;
+                # turn it into a clickable link into Tempo so a log jumps to its
+                # trace (the reverse of Tempo's tracesToLogsV2 below).
+                jsonData.derivedFields = [
+                  {
+                    name = "trace_id";
+                    matcherType = "label";
+                    matcherRegex = "trace_id";
+                    datasourceUid = "tempo";
+                    url = "\${__value.raw}";
+                    urlDisplayLabel = "View trace";
+                  }
+                ];
+              }
+              {
+                name = "Tempo";
+                type = "tempo";
+                uid = "tempo";
+                url = "http://127.0.0.1:${toString config.services.tempo.settings.server.http_listen_port}";
+                # Jump from a trace span to the matching Claude Code events in
+                # Loki. filterByTraceID narrows to the span's trace so the log
+                # panel is not flooded with the whole time range.
+                jsonData.tracesToLogsV2 = {
+                  datasourceUid = "loki";
+                  spanStartTimeShift = "-1h";
+                  spanEndTimeShift = "1h";
+                  filterByTraceID = true;
+                };
               }
             ];
             dashboards.settings = {

--- a/modules/features/otel-collector.nix
+++ b/modules/features/otel-collector.nix
@@ -1,0 +1,90 @@
+{ lib, ... }:
+let
+  # Receives OTLP from Claude Code on localhost and fans the three signals out
+  # to the central manyara stack: metrics via remote_write to Prometheus, logs
+  # to Loki's native OTLP endpoint, and traces via OTLP to Tempo. Claude Code
+  # sessions are too short-lived to scrape, so metrics have to be pushed like
+  # the logs already are. Same body for nixos and darwin: it only appends an
+  # alloy config snippet, and Alloy runs on both platforms via my.services.alloy.
+  module =
+    { config, inputs, ... }:
+    let
+      cfg = config.my.services.otel-collector;
+
+      hostname = config.networking.hostName;
+      manyara = inputs.self.outputs.nixosConfigurations.manyara.config;
+      # Full tailnet FQDN, matching systems/shared/comin/alloy.nix: the short
+      # name resolves inconsistently across Linux and macOS resolvers.
+      host = "manyara.tail4108.ts.net";
+      prometheusEndpoint = "http://${host}:${toString manyara.services.prometheus.port}/api/v1/write";
+      # Loki's native OTLP ingest path. It promotes the service.name resource
+      # attribute to a service_name label by default, so events are queryable as
+      # {service_name="claude-code"} without hint plumbing on the Alloy side.
+      lokiEndpoint = "http://${host}:${toString manyara.services.loki.configuration.server.http_listen_port}/otlp";
+      # Standard OTLP/gRPC port, matching the receiver in modules/features/tempo.nix.
+      tempoEndpoint = "${host}:4317";
+    in
+    {
+      options.my.services.otel-collector.enable =
+        lib.mkEnableOption "Alloy OTLP receiver for Claude Code telemetry";
+
+      config = lib.mkIf cfg.enable {
+        my.services.alloy.configs.otlp = ''
+          otelcol.receiver.otlp "claude_code" {
+            grpc {
+              endpoint = "127.0.0.1:4317"
+            }
+
+            http {
+              endpoint = "127.0.0.1:4318"
+            }
+
+            output {
+              metrics = [otelcol.exporter.prometheus.claude_code.input]
+              logs    = [otelcol.exporter.otlphttp.loki.input]
+              traces  = [otelcol.exporter.otlp.claude_code.input]
+            }
+          }
+
+          otelcol.exporter.prometheus "claude_code" {
+            // Drop the unit and _total suffixes so metric names keep the
+            // predictable claude_code_* form the dashboard queries against.
+            add_metric_suffixes = false
+            forward_to          = [prometheus.remote_write.manyara.receiver]
+          }
+
+          prometheus.remote_write "manyara" {
+            // Claude Code metrics carry no host identity of their own; tag them
+            // here so the fleet's sessions are distinguishable in Grafana.
+            external_labels = {
+              host = "${hostname}",
+            }
+
+            endpoint {
+              url = "${prometheusEndpoint}"
+            }
+          }
+
+          otelcol.exporter.otlphttp "loki" {
+            client {
+              endpoint = "${lokiEndpoint}"
+            }
+          }
+
+          otelcol.exporter.otlp "claude_code" {
+            client {
+              endpoint = "${tempoEndpoint}"
+              // Tempo's gRPC receiver is plaintext on the Tailscale network.
+              tls {
+                insecure = true
+              }
+            }
+          }
+        '';
+      };
+    };
+in
+{
+  flake.modules.nixos.otel-collector = module;
+  flake.modules.darwin.otel-collector = module;
+}

--- a/modules/features/prometheus.nix
+++ b/modules/features/prometheus.nix
@@ -125,8 +125,17 @@
           })
         ];
 
+        # Tailscale-only network, but firewall is still strict -- open the
+        # Prometheus port so Alloy clients on other hosts can remote_write the
+        # push-only Claude Code metrics (ephemeral CLI sessions cannot be
+        # scraped).
+        networking.firewall.allowedTCPPorts = [ config.services.prometheus.port ];
+
         services.prometheus = {
           enable = true;
+          # The remote-write receiver is off by default; without it the fleet's
+          # Alloy has nowhere to push the OTLP-sourced Claude Code metrics.
+          extraFlags = [ "--web.enable-remote-write-receiver" ];
           scrapeConfigs = [
             {
               job_name = "node";

--- a/modules/features/tempo.nix
+++ b/modules/features/tempo.nix
@@ -1,0 +1,64 @@
+{ ... }:
+{
+  flake.modules.nixos.tempo =
+    { config, lib, ... }:
+    let
+      inherit (lib) mkEnableOption mkIf;
+      cfg = config.my.services.tempo;
+      otlpGrpcPort = 4317;
+      stateDir = "/var/lib/tempo";
+    in
+    {
+      options.my.services.tempo.enable = mkEnableOption "Grafana Tempo trace backend";
+
+      config = mkIf cfg.enable {
+        services.tempo = {
+          enable = true;
+
+          # Tempo 3.x runs monolithic (target=all) without Kafka, but its rewritten
+          # write path (live-store) and compaction coordinator (backend-scheduler)
+          # replace the old ingester/compactor and default their working dirs to
+          # /var/tempo -- outside the module's sandboxed StateDirectory. Every path
+          # below is therefore pinned under /var/lib/tempo, or the service crashes
+          # on a permission-denied mkdir at startup.
+          settings = {
+            server = {
+              http_listen_port = 3200;
+              # Loki already binds Tempo's default gRPC port (9095); move Tempo's
+              # internal gRPC server off it. Nothing external targets this port --
+              # trace ingestion goes through the OTLP receiver below.
+              grpc_listen_port = 9096;
+            };
+
+            # Only the gRPC receiver is exposed: the fleet's Alloy instances push
+            # traces over OTLP/gRPC, so the HTTP receiver would be an unused open
+            # port. Bound to all interfaces because the pushers live on other
+            # hosts (reachable over Tailscale), not localhost.
+            distributor.receivers.otlp.protocols.grpc.endpoint = "0.0.0.0:${toString otlpGrpcPort}";
+
+            storage.trace = {
+              backend = "local";
+              local.path = "${stateDir}/blocks";
+              wal.path = "${stateDir}/wal";
+            };
+
+            live_store = {
+              wal.path = "${stateDir}/live-store/traces";
+              shutdown_marker_dir = "${stateDir}/live-store/shutdown-marker";
+            };
+
+            backend_scheduler.local_work_path = "${stateDir}/scheduler";
+
+            # Retention moved out of the removed compactor into overrides. Match
+            # Loki's 30-day window so traces and their correlated logs age out
+            # together.
+            overrides.defaults.compaction.block_retention = "720h";
+          };
+        };
+
+        # Tailscale-only network, but firewall is still strict -- open the OTLP
+        # gRPC port so Alloy clients on other hosts can push traces.
+        networking.firewall.allowedTCPPorts = [ otlpGrpcPort ];
+      };
+    };
+}

--- a/modules/profiles/development.nix
+++ b/modules/profiles/development.nix
@@ -2,6 +2,10 @@
 import ../../lib/mkProfile.nix { inherit lib; } {
   name = "development";
 
+  system = {
+    my.services.otel-collector.enable = lib.mkDefault true;
+  };
+
   home = {
     my.programs.mcp.enable = lib.mkDefault true;
     my.programs.claude-code.enable = lib.mkDefault true;


### PR DESCRIPTION
## Summary

Collects Claude Code's OpenTelemetry signals (metrics, events, traces) into the manyara observability stack and visualizes them in Grafana.

Previously `OTEL_METRICS_EXPORTER=prometheus` exposed a pull endpoint on the short-lived CLI that nothing scraped, so no data was collected and traces were off. Claude Code now pushes OTLP to a local Alloy receiver that fans out to manyara: metrics → `prometheus.remote_write`, logs → Loki OTLP, traces → a new Tempo backend.

Two commits:
1. **collect** — CC OTLP env, Alloy `otel-collector` snippet, `tempo.nix` (3.x monolithic), Prometheus remote-write receiver; enabled on all dev hosts (arusha/kilimanjaro/katavi/work), Tempo on manyara.
2. **visualize** — Tempo datasource + bidirectional log↔trace correlation, and the Claude Code dashboard.

Design notes: push (not scrape) because sessions are too short-lived; cumulative temporality so Prometheus needs no delta conversion; content logging (prompts/responses/tool IO) fully on for this personal environment.

## Verification

- Validated end-to-end via `testing-manyara` test-deploys: Prometheus `claude_code_*` series (with `host` label), Loki `service_name=claude-code` events, Tempo `claude_code.interaction` traces; all three datasources healthy.
- `nix eval` of the toplevel drv succeeds for all five affected hosts on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)