### PR TITLE
chore(flake): update inputs, pinning the two that cannot follow upstream

### DIFF
--- a/configuration.org
+++ b/configuration.org
@@ -88,6 +88,7 @@ and includes tooling for development, code formatting, and pre-commit hooks.
     # Core
     <<nixpkgs>>
     <<nixpkgs-stable>>
+    <<nixpkgs-cuda>>
     # Flake Infrastructure
     <<flake-parts>>
     # Transitive Dependencies
@@ -184,6 +185,18 @@ Provides stable packages when unstable has build failures or regressions. Mainly
 #+NAME: nixpkgs-stable
 #+begin_src nix
 nixpkgs-stable.url = "git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-26.05";
+#+end_src
+
+***** nixpkgs-cuda
+
+kilimanjaro builds with =cudaSupport=, and those builds are only cached by
+[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]], for the revision at the head of =nixos-unstable-cuda=. That branch
+trails =nixos-unstable-small=, so the =cuda= overlay (see [[file:overlays/configuration.org][overlays/configuration.org]]) takes
+=ollama= and =handy= from this input while the rest of the system follows the main one.
+
+#+NAME: nixpkgs-cuda
+#+begin_src nix
+nixpkgs-cuda.url = "git+https://github.com/nixos-cuda/nixpkgs?shallow=1&ref=nixos-unstable-cuda";
 #+end_src
 
 **** Flake Infrastructure
@@ -690,10 +703,15 @@ The self-improving AI agent built by Nous Research
 Provides the upstream NixOS module (=nixosModules.default=) and packaged Python
 build of hermes-agent.
 
+The URL points at my fork: upstream reads =package.json=, =pyproject.toml= and =uv.lock=
+out of =builtins.path= copies that only materialise under a writable store, so the
+=nix flake check --no-build= CI runs fails with =path '...-hermes-python-source' is not
+valid=. Back to upstream once [[https://github.com/NousResearch/hermes-agent/pull/71228][PR #71228]] merges.
+
 #+NAME: hermes-agent
 #+begin_src nix
 hermes-agent = {
-  url = "github:NousResearch/hermes-agent";
+  url = "github:natsukium/hermes-agent/fix/nix-read-only-eval";
   inputs.flake-parts.follows = "flake-parts";
   inputs.nixpkgs.follows = "nixpkgs";
 };

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "brew-api": {
       "flake": false,
       "locked": {
-        "lastModified": 1782866573,
-        "narHash": "sha256-ETi/fJmanZDfnXmIMyJSWbCysreioc38CcZleBP75t8=",
+        "lastModified": 1784977502,
+        "narHash": "sha256-kW2IuCVM+mSOwPORMAlnLKq99itPK09+ETIqyqUecqE=",
         "owner": "BatteredBunny",
         "repo": "brew-api",
-        "rev": "8dd049afdd8ef1e9e3f26308599f0b3926f001e2",
+        "rev": "86cb14bdfc05035ad31af3400a6b228ffe8b9013",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781801538,
-        "narHash": "sha256-6zUToQ0ydSgpgrMk3GEEVOpWgn9SwVlrP+7tFb9gpOU=",
+        "lastModified": 1784490391,
+        "narHash": "sha256-/qnykj46xlcFPaoiksoGCk4g2g4EtF72ZNzYJtHTmh4=",
         "owner": "BatteredBunny",
         "repo": "brew-nix",
-        "rev": "7614a09c5a86ef717c7cbcd3f4fffeacfb66b30b",
+        "rev": "05377d6a5e6707a1914263ff02df0a5c597374d8",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782515413,
-        "narHash": "sha256-Pb5ngiUtJWO7N8hUtv1dXoViv1IuJUIOKLcOprrfUvU=",
+        "lastModified": 1784613260,
+        "narHash": "sha256-M+WLmuIVbA7XD822F8ZTEbMBKf1FamG1BEL0/aBqcKA=",
         "owner": "nlewo",
         "repo": "comin",
-        "rev": "ec4b64a43faf5261ad4dc35b4e008c2bafc2e8db",
+        "rev": "c32a4e457cd3bc99d6c18631707e9d8294f4b5d0",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1781825982,
-        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782846501,
-        "narHash": "sha256-2Pz2ajx4elc6+J1ptkGAi4HLYTW2vW/jJhQfeZsXq9U=",
+        "lastModified": 1784975750,
+        "narHash": "sha256-JNEjwBSXytKCHGSwG3ReZi6xIubWaLmgcq4siQvTPLI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "049348f7a64744506ea5dfb6c939d780de5214c8",
+        "rev": "7afa297a367ad6d2ad8d7a709960c21bf595cd21",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784881207,
-        "narHash": "sha256-t817YN71pQ9qXCGMfjbKtM5WZr3phLH2d0PldMdvSlI=",
+        "lastModified": 1784886332,
+        "narHash": "sha256-nvZc+UByC26+xLrR0ETi0DsE2r8Vw2h62yXY9UME3H0=",
         "ref": "refs/heads/main",
-        "rev": "e3abf8079bdf0ead89f5d7be0108e41347e46799",
-        "revCount": 1147,
+        "rev": "080a1fd0350678728d62c90bb40bd97618192da8",
+        "revCount": 1148,
         "type": "git",
         "url": "https://git.natsukium.com/natsukium/felis"
       },
@@ -216,11 +216,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1782792494,
-        "narHash": "sha256-bW4jAqiveTSV0yzAxdJFzm9BMkDCp7pQFP9r5uWyL2c=",
+        "lastModified": 1784963334,
+        "narHash": "sha256-Xbj8fFapX+ufz8kx0sH33RAvF0Pauzfg5oihn38SWtE=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "4190ad0839af55e6d2dc47e7898c00104710b7c0",
+        "rev": "557935d63e75f4bfbd61ca3cede3a632edbed7e5",
         "type": "gitlab"
       },
       "original": {
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -287,17 +287,16 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": [],
-        "gitignore": [],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -316,19 +315,20 @@
         ],
         "npm-lockfile-fix": "npm-lockfile-fix",
         "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix_2",
-        "uv2nix": "uv2nix_2"
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782871185,
-        "narHash": "sha256-NfjKXlbORQLthJKWPhrxYcp3Fs/s2vCL6+SW3PCo5B4=",
-        "owner": "NousResearch",
+        "lastModified": 1784956991,
+        "narHash": "sha256-8kP4WfotQdfwtqf8PQnJ/Cuqg8f7O+QdbW+GtCvf7nk=",
+        "owner": "natsukium",
         "repo": "hermes-agent",
-        "rev": "a653bb0cbeaaefc1e275b2e3408c3968011d1304",
+        "rev": "921caddb10b29c283c4e2697e54d53011bf1cd28",
         "type": "github"
       },
       "original": {
-        "owner": "NousResearch",
+        "owner": "natsukium",
+        "ref": "fix/nix-read-only-eval",
         "repo": "hermes-agent",
         "type": "github"
       }
@@ -340,11 +340,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782839684,
-        "narHash": "sha256-vzs4SBgPsK4aNzlJR2PpFwtARazXMOxZonQnDz0YHxk=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a37d71bbe69e1522ddabf03a4cea0374958bdbe",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782160136,
-        "narHash": "sha256-APwmLI4UuSTim0JO/kZ6FXDPiZVp3zIj0uGDF2UZ5kU=",
+        "lastModified": 1784568171,
+        "narHash": "sha256-t17AqLEhPG6m27ipkp8mJd8Ug0XkdANFDVsgyIFBZcQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6650fb7c6b48177c8200e21ffac99a4adc72b08d",
+        "rev": "f4b0aef3dba28677a5ca4b3416827aade60b5a0b",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782786003,
-        "narHash": "sha256-jZ+N/sWZV7jbOQVDN8ZBqaQFe94CrUrhIIibvmFc9tM=",
+        "lastModified": 1784974217,
+        "narHash": "sha256-vYMTOExlquQSKCV5K/VjROLlfJ2D7IyAzvlvv2KAntk=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "e2e5ce54691fc6c851e7365da0cd67ad88962c4c",
+        "rev": "4c03cc7e3088420b8b84d8d0937036abe13bf7a7",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1782764610,
-        "narHash": "sha256-CzCF8RD9a9kwRrpeQ+z67sqqADUG0tf+4+YBSUG30y0=",
+        "lastModified": 1784666190,
+        "narHash": "sha256-xgfS6slV7J3baMooNN1UuBi51RIgg9y0DbCxfSA0668=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "3904edd282a7166cdad6c597964718e6d018baa6",
+        "rev": "fa5340ac684cdce8a22b6d4a0bcebb0cc999275e",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782810950,
-        "narHash": "sha256-Ami+rQ4DLI8WCwLTN62RBkgTzE24rY5NYsvgHGbFfug=",
+        "lastModified": 1784621916,
+        "narHash": "sha256-JGjvWpNNrbhiYhx+z9l/iDw1J48TrirfZC6R3yWjmU4=",
         "owner": "Mic92",
         "repo": "niks3",
-        "rev": "780939adecefc2f84be700a6f9ae1cc9385ad240",
+        "rev": "abbc291d372d2d821327516b5f5224de03113204",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
         "xwayland-satellite-unstable": []
       },
       "locked": {
-        "lastModified": 1782797405,
-        "narHash": "sha256-WyU7TxkLHtzR+96Cx6d6UDFapASOrWmLFYVbJdBBUaI=",
+        "lastModified": 1784874881,
+        "narHash": "sha256-u4jhSIf/Un0qZB+Cn3hTTaHSI20XeAxYbA5o4faqdJs=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "5d2a6c89ac5b3f2d403892edd071383f050890b0",
+        "rev": "ef7a2a3d719af46b906c22a3ebfb7d65627b2cd2",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781182279,
-        "narHash": "sha256-V5EQQbDnmdiXGQXrEF1PEL7QYsFqfH8N1E89Z5ONwFk=",
+        "lastModified": 1784642409,
+        "narHash": "sha256-hcbDqFuySAJawljt5r0sKBCJKYnbtGD0T/ZIozH1Dq0=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "5675822ba756e6e56f8f6a5a76e90e0da2ece94d",
+        "rev": "eaeb18da90024448a60eb1ec7132eafa4003404e",
         "type": "github"
       },
       "original": {
@@ -653,6 +653,23 @@
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "nixpkgs-cuda": {
+      "locked": {
+        "lastModified": 1783306753,
+        "narHash": "sha256-yBvwRKoVMLe2a1nQvFZCDN5/zjiO2MiMzuIJWc/VW9U=",
+        "ref": "nixos-unstable-cuda",
+        "rev": "38f52fc9057a249e1e9c93e2781e439aad5a10bd",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/nixos-cuda/nixpkgs"
+      },
+      "original": {
+        "ref": "nixos-unstable-cuda",
+        "shallow": true,
+        "type": "git",
+        "url": "https://github.com/nixos-cuda/nixpkgs"
       }
     },
     "nixpkgs-libxml2": {
@@ -706,10 +723,10 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1782860505,
-        "narHash": "sha256-7beKprxZK6AT2aNMCLFUBew5g18GfWZYAbWIuxK7R3c=",
+        "lastModified": 1784966893,
+        "narHash": "sha256-WCrs/9bdH+gzSZit3UrSa4sWdyZ8+uC5x5bymPgBHMg=",
         "ref": "nixos-unstable-small",
-        "rev": "39b92caca76274e7673f27b09d6c3734df0ed931",
+        "rev": "328e42b4f861ae88cf3643962ed5c4ff918f2ba8",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/nixos/nixpkgs"
@@ -765,11 +782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784451022,
-        "narHash": "sha256-hDKURPdXgasGPDCsyJRNWnPsXqdLfRQ/uMelseRuTEE=",
+        "lastModified": 1784967360,
+        "narHash": "sha256-qnKrKFglKgjdBfOdB8lRpdD0O7cy+cMDX/n6Q+EjKcA=",
         "owner": "natsukium",
         "repo": "nur-packages",
-        "rev": "ecbf1863ca9603856263ac65a703d3e9e2b00ada",
+        "rev": "38c189ccc9ad246f14f104d2981995ae5919f094",
         "type": "github"
       },
       "original": {
@@ -828,8 +845,14 @@
           "hermes-agent",
           "nixpkgs"
         ],
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
       },
       "locked": {
         "lastModified": 1772555609,
@@ -849,28 +872,6 @@
       "inputs": {
         "nixpkgs": [
           "hermes-agent",
-          "pyproject-build-systems",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769936401,
-        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
-        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
           "nixpkgs"
         ]
       },
@@ -880,28 +881,6 @@
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
         "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "uv2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1771518446,
-        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
         "type": "github"
       },
       "original": {
@@ -938,6 +917,7 @@
         "nixos-facter-modules": "nixos-facter-modules",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-cuda": "nixpkgs-cuda",
         "nixpkgs-stable": "nixpkgs-stable",
         "nur-packages": "nur-packages",
         "org-clickup": "org-clickup",
@@ -980,11 +960,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1784438913,
+        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
         "type": "github"
       },
       "original": {
@@ -1041,11 +1021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -1076,11 +1056,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1782480951,
-        "narHash": "sha256-jrfyAgv5XfYDXJJ28OzANQOQIlsfNaI1kM9Mt13n+5k=",
+        "lastModified": 1783694892,
+        "narHash": "sha256-xO8f7Qng+18FK2UlB9vcrkxCaQMCt5WjCH24aW/11eg=",
         "ref": "refs/heads/main",
-        "rev": "e4562d4c7646fea3cbb7306ff9b7ff41154c75c3",
-        "revCount": 1400,
+        "rev": "24c4346e30fdea8d8e80f34aec3554a15a667d24",
+        "revCount": 1410,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -1168,11 +1148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -1208,36 +1188,12 @@
       "inputs": {
         "nixpkgs": [
           "hermes-agent",
-          "pyproject-build-systems",
           "nixpkgs"
         ],
         "pyproject-nix": [
           "hermes-agent",
-          "pyproject-build-systems",
           "pyproject-nix"
         ]
-      },
-      "locked": {
-        "lastModified": 1770770348,
-        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "type": "github"
-      }
-    },
-    "uv2nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ],
-        "pyproject-nix": "pyproject-nix_3"
       },
       "locked": {
         "lastModified": 1773039484,
@@ -1285,11 +1241,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782812215,
-        "narHash": "sha256-OPVK9WW9QsO2aj1R+Ln3p7fniFj5h441vb3LyrzpeE4=",
+        "lastModified": 1784834038,
+        "narHash": "sha256-7kFP+NUILPvdhO7mQk90h2MnseMNvYzGPpclhmJEKF0=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "a7c2a9a5e492e0e62072547f7e4c2abf138425c5",
+        "rev": "35443b74c3481fb963ee0a53175ab0e8001f2967",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     # Core
     nixpkgs.url = "git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-unstable-small";
     nixpkgs-stable.url = "git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-26.05";
+    nixpkgs-cuda.url = "git+https://github.com/nixos-cuda/nixpkgs?shallow=1&ref=nixos-unstable-cuda";
     # Flake Infrastructure
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -126,7 +127,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     hermes-agent = {
-      url = "github:NousResearch/hermes-agent";
+      url = "github:natsukium/hermes-agent/fix/nix-read-only-eval";
       inputs.flake-parts.follows = "flake-parts";
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/overlays/configuration.org
+++ b/overlays/configuration.org
@@ -11,10 +11,12 @@ would otherwise block the system build or cause runtime problems.
 For details on overlay mechanics (=final: prev:= pattern, composition order, etc.),
 see [[https://nixos.org/manual/nixpkgs/stable/#chap-overlays][nixpkgs overlay documentation]].
 
-Overlays are organized into four categories based on their purpose and expected lifetime:
+Overlays are organized into five categories based on their purpose and expected lifetime:
 
 - *stable*: Packages fetched from nixpkgs-stable when broken in unstable and the fix would
   trigger excessive rebuilds or is too complex to patch locally.
+- *cuda*: Packages taken from the CUDA channel, the only revision whose CUDA builds are
+  cached.
 - *temporary-fix*: Local overrides (e.g., disabling tests) that don't require a different
   nixpkgs version. Remove once fixed upstream.
 - *pre-release*: Alpha, beta, or pre-release packages for testing before they land in nixpkgs.
@@ -30,6 +32,8 @@ Overlays are organized into four categories based on their purpose and expected 
 { inputs }:
 {
   <<stable>>
+
+  <<cuda>>
 
   <<temporary-fix>>
 
@@ -49,6 +53,36 @@ to patch locally.
 #+begin_src nix
 stable = final: prev: {
 };
+#+end_src
+
+** cuda
+
+[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]] only covers the head of =nixos-unstable-cuda=, so kilimanjaro takes
+its CUDA packages from =nixpkgs-cuda=. Naming =ollama= and =handy= is enough:
+=onnxruntime=, =openvino=, =opencv= and =cudnn-frontend= are only reachable through them.
+
+The package set is imported plain because the CUDA Hydra builds plain nixpkgs, and a local
+overlay reaching into that closure would move the store paths off the cache. The guard
+keeps the pin off hosts that leave =cudaSupport= unset.
+
+#+NAME: cuda
+#+begin_src nix
+cuda =
+  final: prev:
+  prev.lib.optionalAttrs (prev.config.cudaSupport or false) (
+    let
+      pkgs = import inputs.nixpkgs-cuda {
+        inherit (prev.stdenv.hostPlatform) system;
+        config = {
+          cudaSupport = true;
+          allowUnfree = true;
+        };
+      };
+    in
+    {
+      inherit (pkgs) handy ollama;
+    }
+  );
 #+end_src
 
 ** temporary-fix

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -6,6 +6,23 @@
   stable = final: prev: {
   };
 
+  cuda =
+    final: prev:
+    prev.lib.optionalAttrs (prev.config.cudaSupport or false) (
+      let
+        pkgs = import inputs.nixpkgs-cuda {
+          inherit (prev.stdenv.hostPlatform) system;
+          config = {
+            cudaSupport = true;
+            allowUnfree = true;
+          };
+        };
+      in
+      {
+        inherit (pkgs) handy ollama;
+      }
+    );
+
   temporary-fix = final: prev: {
     python313 = prev.python313.override {
       packageOverrides = pyfinal: pyprev: {

--- a/po/dotfiles.pot
+++ b/po/dotfiles.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 18:20+0900\n"
+"POT-Creation-Date: 2026-07-25 21:57+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,7 +164,7 @@ msgid "Role"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:35 configuration.org:956 .github/README.org:28
+#: configuration.org:35 configuration.org:974 .github/README.org:28
 #, no-wrap
 msgid "kilimanjaro"
 msgstr ""
@@ -190,7 +190,7 @@ msgid "Main desktop"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:36 configuration.org:1026 .github/README.org:29
+#: configuration.org:36 configuration.org:1044 .github/README.org:29
 #, no-wrap
 msgid "tarangire"
 msgstr ""
@@ -209,7 +209,7 @@ msgid "Build server"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:37 configuration.org:1014 .github/README.org:30
+#: configuration.org:37 configuration.org:1032 .github/README.org:30
 #, no-wrap
 msgid "manyara"
 msgstr ""
@@ -227,7 +227,7 @@ msgid "Home server"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:38 configuration.org:963 .github/README.org:31
+#: configuration.org:38 configuration.org:981 .github/README.org:31
 #, no-wrap
 msgid "arusha"
 msgstr ""
@@ -245,7 +245,7 @@ msgid "WSL environment"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:39 configuration.org:1022 .github/README.org:32
+#: configuration.org:39 configuration.org:1040 .github/README.org:32
 #, no-wrap
 msgid "serengeti"
 msgstr ""
@@ -263,7 +263,7 @@ msgid "OCI A1 Flex"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:40 configuration.org:944 .github/README.org:33
+#: configuration.org:40 configuration.org:962 .github/README.org:33
 #, no-wrap
 msgid "katavi"
 msgstr ""
@@ -288,7 +288,7 @@ msgid "Main laptop"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:41 configuration.org:952 .github/README.org:34
+#: configuration.org:41 configuration.org:970 .github/README.org:34
 #, no-wrap
 msgid "work"
 msgstr ""
@@ -306,7 +306,7 @@ msgid "Work laptop"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:42 configuration.org:948 .github/README.org:35
+#: configuration.org:42 configuration.org:966 .github/README.org:35
 #, no-wrap
 msgid "mikumi"
 msgstr ""
@@ -318,13 +318,13 @@ msgid "M1 Mac mini"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:43 configuration.org:1033 .github/README.org:36
+#: configuration.org:43 configuration.org:1051 .github/README.org:36
 #, no-wrap
 msgid "android"
 msgstr ""
 
 #. type: cell column 1
-#: configuration.org:43 configuration.org:288 configuration.org:299
+#: configuration.org:43 configuration.org:301 configuration.org:312
 #: .github/README.org:36
 #, no-wrap
 msgid "nix-on-droid"
@@ -440,6 +440,7 @@ msgid ""
 "inputs = {\n"
 "  <<nixpkgs>>\n"
 "  <<nixpkgs-stable>>\n"
+"  <<nixpkgs-cuda>>\n"
 "  <<flake-parts>>\n"
 "  <<flake-utils>>\n"
 "  <<darwin>>\n"
@@ -478,7 +479,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:134
+#: configuration.org:135
 #, no-wrap
 msgid ""
 "nixConfig = {\n"
@@ -487,7 +488,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:138
+#: configuration.org:139
 #, no-wrap
 msgid ""
 "  outputs =\n"
@@ -499,18 +500,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:146
+#: configuration.org:147
 #, no-wrap
 msgid "Inputs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:148
+#: configuration.org:149
 msgid "External flake dependencies."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:150
+#: configuration.org:151
 msgid ""
 "To minimize evaluation time caused by dependency graph bloat, almost all "
 "flakes are configured to follow the same nixpkgs and other common inputs "
@@ -518,29 +519,29 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:153
+#: configuration.org:154
 #, no-wrap
 msgid "Core"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:155 configuration.org:174
+#: configuration.org:156 configuration.org:175
 #, no-wrap
 msgid "nixpkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:157
+#: configuration.org:158
 msgid "https://github.com/NixOS/nixpkgs"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:160
+#: configuration.org:161
 msgid "Nix Packages collection & NixOS"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:163
+#: configuration.org:164
 msgid ""
 "The primary package set. Using =nixos-unstable-small= instead of "
 "=nixos-unstable= for faster channel updates. The =-small= variant skips some "
@@ -549,26 +550,26 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:167
+#: configuration.org:168
 msgid ""
 "For channel selection guidance, see "
 "https://nix.dev/concepts/faq.html#which-channel-branch-should-i-use"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:169
+#: configuration.org:170
 msgid "Channel status can be checked at https://status.nixos.org/"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:171
+#: configuration.org:172
 msgid ""
 "Using =git+https://= with =shallow=1= instead of =github:= for slightly "
 "faster file extraction on large repositories like nixpkgs."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:176
+#: configuration.org:177
 #, no-wrap
 msgid ""
 "nixpkgs.url = "
@@ -576,13 +577,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:179 configuration.org:184
+#: configuration.org:180 configuration.org:185
 #, no-wrap
 msgid "nixpkgs-stable"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:181
+#: configuration.org:182
 msgid ""
 "Provides stable packages when unstable has build failures or "
 "regressions. Mainly used by the =stable= overlay (see "
@@ -591,37 +592,63 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:186
+#: configuration.org:187
 #, no-wrap
 msgid ""
 "nixpkgs-stable.url = "
 "\"git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-26.05\";"
 msgstr ""
 
+#. type: keyword NAME
+#: configuration.org:190 configuration.org:197
+#, no-wrap
+msgid "nixpkgs-cuda"
+msgstr ""
+
+#. type: paragraph
+#: configuration.org:192
+msgid ""
+"kilimanjaro builds with =cudaSupport=, and those builds are only cached by "
+"[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]], for the revision at "
+"the head of =nixos-unstable-cuda=. That branch trails "
+"=nixos-unstable-small=, so the =cuda= overlay (see "
+"[[file:overlays/configuration.org][overlays/configuration.org]]) takes "
+"=ollama= and =handy= from this input while the rest of the system follows "
+"the main one."
+msgstr ""
+
+#. type: paragraph in src
+#: configuration.org:199
+#, no-wrap
+msgid ""
+"nixpkgs-cuda.url = "
+"\"git+https://github.com/nixos-cuda/nixpkgs?shallow=1&ref=nixos-unstable-cuda\";"
+msgstr ""
+
 #. type: heading ****
-#: configuration.org:189
+#: configuration.org:202
 #, no-wrap
 msgid "Flake Infrastructure"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:191 configuration.org:202
+#: configuration.org:204 configuration.org:215
 #, no-wrap
 msgid "flake-parts"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:193
+#: configuration.org:206
 msgid "https://github.com/hercules-ci/flake-parts"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:196
+#: configuration.org:209
 msgid "Simplify Nix Flakes with the module system"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:199
+#: configuration.org:212
 msgid ""
 "Framework for organizing flake outputs. Provides module system for flakes, "
 "making complex configurations more maintainable through separation of "
@@ -629,7 +656,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:204
+#: configuration.org:217
 #, no-wrap
 msgid ""
 "flake-parts = {\n"
@@ -639,64 +666,64 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:210
+#: configuration.org:223
 #, no-wrap
 msgid "Transitive Dependencies"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:212 configuration.org:223
+#: configuration.org:225 configuration.org:236
 #, no-wrap
 msgid "flake-utils"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:214
+#: configuration.org:227
 msgid "https://github.com/numtide/flake-utils"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:217
+#: configuration.org:230
 msgid "Pure Nix flake utility functions"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:220
+#: configuration.org:233
 msgid ""
 "Common flake utilities. Only used transitively via =follows= to unify the "
 "flake-utils version across inputs that depend on it."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:225
+#: configuration.org:238
 #, no-wrap
 msgid "flake-utils.url = \"github:numtide/flake-utils\";"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:228
+#: configuration.org:241
 #, no-wrap
 msgid "System Configuration"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:230 configuration.org:241
+#: configuration.org:243 configuration.org:254
 #, no-wrap
 msgid "darwin"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:232
+#: configuration.org:245
 msgid "https://github.com/nix-darwin/nix-darwin"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:235
+#: configuration.org:248
 msgid "Manage your macOS using Nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:238
+#: configuration.org:251
 msgid ""
 "nix-darwin provides NixOS-style system configuration for macOS. Essential "
 "for managing macOS system settings, launchd services, and Homebrew "
@@ -704,7 +731,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:243
+#: configuration.org:256
 #, no-wrap
 msgid ""
 "darwin = {\n"
@@ -714,23 +741,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:249 configuration.org:260
+#: configuration.org:262 configuration.org:273
 #, no-wrap
 msgid "home-manager"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:251
+#: configuration.org:264
 msgid "https://github.com/nix-community/home-manager"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:254
+#: configuration.org:267
 msgid "Manage a user environment using Nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:257
+#: configuration.org:270
 msgid ""
 "User environment management. Manages dotfiles, user services, and per-user "
 "packages declaratively. The backbone of user-level configuration in this "
@@ -738,7 +765,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:262
+#: configuration.org:275
 #, no-wrap
 msgid ""
 "home-manager = {\n"
@@ -748,30 +775,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:268 configuration.org:279
+#: configuration.org:281 configuration.org:292
 #, no-wrap
 msgid "nixos-wsl"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:270
+#: configuration.org:283
 msgid "https://github.com/nix-community/nixos-wsl"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:273
+#: configuration.org:286
 msgid "NixOS on WSL"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:276
+#: configuration.org:289
 msgid ""
 "NixOS on Windows Subsystem for Linux. Provides NixOS experience within WSL2, "
 "useful for Windows machines that need Linux development environments."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:281
+#: configuration.org:294
 #, no-wrap
 msgid ""
 "nixos-wsl = {\n"
@@ -782,24 +809,24 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:290
+#: configuration.org:303
 msgid "https://github.com/nix-community/nix-on-droid"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:293
+#: configuration.org:306
 msgid "Nix-enabled environment for your Android device."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:296
+#: configuration.org:309
 msgid ""
 "Nix environment for Android via Termux. Enables the same declarative "
 "configuration approach on mobile devices."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:301
+#: configuration.org:314
 #, no-wrap
 msgid ""
 "nix-on-droid = {\n"
@@ -814,30 +841,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:312 configuration.org:323
+#: configuration.org:325 configuration.org:336
 #, no-wrap
 msgid "disko"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:314
+#: configuration.org:327
 msgid "https://github.com/nix-community/disko"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:317
+#: configuration.org:330
 msgid "Declarative disk partitioning and formatting using nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:320
+#: configuration.org:333
 msgid ""
 "Used for reproducible NixOS installations with automated partition layout, "
 "filesystem creation, and encryption setup."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:325
+#: configuration.org:338
 #, no-wrap
 msgid ""
 "disko = {\n"
@@ -847,25 +874,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:331 configuration.org:342
+#: configuration.org:344 configuration.org:355
 #, no-wrap
 msgid "impermanence"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:333
+#: configuration.org:346
 msgid "https://github.com/nix-community/impermanence"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:336
+#: configuration.org:349
 msgid ""
 "Modules to help you handle persistent state on systems with ephemeral root "
 "storage"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:339
+#: configuration.org:352
 msgid ""
 "Manages stateful paths on systems with ephemeral root filesystems. Used with "
 "btrfs snapshots to ensure only explicitly declared state persists across "
@@ -873,36 +900,36 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:344
+#: configuration.org:357
 #, no-wrap
 msgid "impermanence.url = \"github:nix-community/impermanence\";"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:347 configuration.org:357
+#: configuration.org:360 configuration.org:370
 #, no-wrap
 msgid "lanzaboote"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:349
+#: configuration.org:362
 msgid "https://github.com/nix-community/lanzaboote"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:352
+#: configuration.org:365
 msgid "Secure Boot for NixOS"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:355
+#: configuration.org:368
 msgid ""
 "Signs boot components with custom keys, enabling Secure Boot on NixOS "
 "machines."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:359
+#: configuration.org:372
 #, no-wrap
 msgid ""
 "lanzaboote = {\n"
@@ -913,58 +940,58 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:366 configuration.org:377
+#: configuration.org:379 configuration.org:390
 #, no-wrap
 msgid "nixos-facter-modules"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:368
+#: configuration.org:381
 msgid "https://github.com/numtide/nixos-facter-modules"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:371
+#: configuration.org:384
 msgid "A series of NixOS modules to be used in conjunction with nixos-facter"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:374
+#: configuration.org:387
 msgid ""
 "Hardware detection for NixOS. Automatically generates hardware configuration "
 "based on detected hardware, simplifying initial system setup."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:379
+#: configuration.org:392
 #, no-wrap
 msgid "nixos-facter-modules.url = \"github:numtide/nixos-facter-modules\";"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:382
+#: configuration.org:395
 #, no-wrap
 msgid "Infrastructure"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:384 configuration.org:395
+#: configuration.org:397 configuration.org:408
 #, no-wrap
 msgid "comin"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:386
+#: configuration.org:399
 msgid "https://github.com/nlewo/comin"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:389
+#: configuration.org:402
 msgid "GitOps For NixOS Machines"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:392
+#: configuration.org:405
 msgid ""
 "Automatically deploys configuration changes when pushed to the repository, "
 "enabling continuous deployment for servers without manual =nixos-rebuild "
@@ -972,7 +999,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:397
+#: configuration.org:410
 #, no-wrap
 msgid ""
 "comin = {\n"
@@ -982,25 +1009,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:403 configuration.org:418
+#: configuration.org:416 configuration.org:431
 #, no-wrap
 msgid "microvm"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:405
+#: configuration.org:418
 msgid "https://github.com/astro/microvm.nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:408
+#: configuration.org:421
 msgid ""
 "NixOS modules for declaring & running virtual machines from within your "
 "system Flake configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:411
+#: configuration.org:424
 msgid ""
 "Lightweight per-VM isolation suitable for running somewhat untrusted code.  "
 "Used to sandbox third-party agent code (hermes-agent) so crashes, runaway "
@@ -1011,7 +1038,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:420
+#: configuration.org:433
 #, no-wrap
 msgid ""
 "microvm = {\n"
@@ -1021,30 +1048,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:426 configuration.org:437
+#: configuration.org:439 configuration.org:450
 #, no-wrap
 msgid "sops-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:428
+#: configuration.org:441
 msgid "https://github.com/Mic92/sops-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:431
+#: configuration.org:444
 msgid "Atomic secret provisioning for NixOS based on sops"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:434
+#: configuration.org:447
 msgid ""
 "Secrets management using Mozilla SOPS. Encrypts secrets in the repository "
 "that are decrypted at activation time using age keys."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:439
+#: configuration.org:452
 #, no-wrap
 msgid ""
 "sops-nix = {\n"
@@ -1054,32 +1081,32 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:445 configuration.org:456
+#: configuration.org:458 configuration.org:469
 #, no-wrap
 msgid "tsnsrv"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:447
+#: configuration.org:460
 msgid "https://github.com/boinkor-net/tsnsrv"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:450
+#: configuration.org:463
 msgid ""
 "A reverse proxy that exposes services on your tailnet (as their own "
 "tailscale participants)"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:453
+#: configuration.org:466
 msgid ""
 "Tailscale service proxy. Exposes local services to the Tailscale network "
 "with automatic HTTPS certificates."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:458
+#: configuration.org:471
 #, no-wrap
 msgid ""
 "tsnsrv = {\n"
@@ -1090,23 +1117,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:465 configuration.org:481
+#: configuration.org:478 configuration.org:494
 #, no-wrap
 msgid "niks3"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:467
+#: configuration.org:480
 msgid "https://github.com/Mic92/niks3"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:470
+#: configuration.org:483
 msgid "S3-backed Nix binary cache with garbage collection"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:473
+#: configuration.org:486
 msgid ""
 "niks3 is a self-hosted, S3-backed Nix binary cache that resolves the upload "
 "limits I ran into with the alternatives: it hands clients presigned S3 URLs "
@@ -1119,7 +1146,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:483
+#: configuration.org:496
 #, no-wrap
 msgid ""
 "niks3 = {\n"
@@ -1130,29 +1157,29 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:490
+#: configuration.org:503
 #, no-wrap
 msgid "Development Tools"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:492 configuration.org:505
+#: configuration.org:505 configuration.org:518
 #, no-wrap
 msgid "git-hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:494
+#: configuration.org:507
 msgid "https://github.com/cachix/git-hooks.nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:497
+#: configuration.org:510
 msgid "Seamless integration of pre-commit.com git hooks with Nix."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:500
+#: configuration.org:513
 msgid ""
 "Pre-commit hooks as Nix derivations. Ensures code quality checks run "
 "consistently across all development environments without requiring global "
@@ -1160,12 +1187,12 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:503
+#: configuration.org:516
 msgid "Inputs that don't affect this flake are removed to prevent lockfile bloat."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:507
+#: configuration.org:520
 #, no-wrap
 msgid ""
 "git-hooks = {\n"
@@ -1177,23 +1204,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:515 configuration.org:526
+#: configuration.org:528 configuration.org:539
 #, no-wrap
 msgid "treefmt-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:517
+#: configuration.org:530
 msgid "https://github.com/numtide/treefmt-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:520
+#: configuration.org:533
 msgid "treefmt nix configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:523
+#: configuration.org:536
 msgid ""
 "Unified code formatter configuration. Runs multiple formatters (oxfmt, "
 "nixfmt, shfmt, etc.)  through a single interface, ensuring consistent "
@@ -1201,7 +1228,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:528
+#: configuration.org:541
 #, no-wrap
 msgid ""
 "treefmt-nix = {\n"
@@ -1211,36 +1238,36 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:534
+#: configuration.org:547
 #, no-wrap
 msgid "Desktop & Theming"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:536 configuration.org:547
+#: configuration.org:549 configuration.org:560
 #, no-wrap
 msgid "nix-colors"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:538
+#: configuration.org:551
 msgid "https://github.com/misterio77/nix-colors"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:541
+#: configuration.org:554
 msgid "Modules and schemes to make theming with Nix awesome."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:544
+#: configuration.org:557
 msgid ""
 "Base16 color scheme framework for Nix. Provides consistent theming across "
 "applications through a single color scheme definition."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:549
+#: configuration.org:562
 #, no-wrap
 msgid ""
 "nix-colors = {\n"
@@ -1250,30 +1277,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:555 configuration.org:566
+#: configuration.org:568 configuration.org:579
 #, no-wrap
 msgid "nix-wallpaper"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:557
+#: configuration.org:570
 msgid "https://github.com/natsukium/nix-wallpaper"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:560
+#: configuration.org:573
 msgid "A configurable wallpaper for nix systems"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:563
+#: configuration.org:576
 msgid ""
 "Generates Nix logo wallpapers. Using a custom branch (=custom-logo=) that "
 "supports additional logo variants."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:568
+#: configuration.org:581
 #, no-wrap
 msgid ""
 "nix-wallpaper = {\n"
@@ -1285,45 +1312,45 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:576
+#: configuration.org:589
 #, no-wrap
 msgid "Applications"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:578 configuration.org:592
+#: configuration.org:591 configuration.org:605
 #, no-wrap
 msgid "brew-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:580
+#: configuration.org:593
 msgid "https://github.com/BatteredBunny/brew-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:583
+#: configuration.org:596
 msgid ""
 "Experimental nix expression to package all MacOS casks from homebrew "
 "automatically"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:586
+#: configuration.org:599
 msgid ""
 "Provides Homebrew casks as Nix packages for darwin. Useful for proprietary "
 "macOS applications not available in nixpkgs."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:589
+#: configuration.org:602
 msgid ""
 "The =brew-api= input is marked as non-flake because it's just a data source "
 "(JSON API dump from Homebrew's API)."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:594
+#: configuration.org:607
 #, no-wrap
 msgid ""
 "brew-api = {\n"
@@ -1339,18 +1366,18 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:606 configuration.org:614
+#: configuration.org:619 configuration.org:627
 #, no-wrap
 msgid "edgepkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:608
+#: configuration.org:621
 msgid "https://github.com/natsukium/edgepkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:610
+#: configuration.org:623
 msgid ""
 "Personal repository for bleeding-edge packages. Contains packages not yet in "
 "nixpkgs, those requiring modifications, or packages that wouldn't be "
@@ -1358,7 +1385,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:616
+#: configuration.org:629
 #, no-wrap
 msgid ""
 "edgepkgs = {\n"
@@ -1368,23 +1395,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:622 configuration.org:635
+#: configuration.org:635 configuration.org:648
 #, no-wrap
 msgid "emacs-overlay"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:624
+#: configuration.org:637
 msgid "https://github.com/nix-community/emacs-overlay"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:627
+#: configuration.org:640
 msgid "Bleeding edge emacs overlay"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:630
+#: configuration.org:643
 msgid ""
 "Provides latest Emacs builds including native compilation and pure GTK "
 "variants.  Also includes MELPA packages updated more frequently than "
@@ -1393,7 +1420,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:637
+#: configuration.org:650
 #, no-wrap
 msgid ""
 "emacs-overlay = {\n"
@@ -1404,23 +1431,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:644 configuration.org:652
+#: configuration.org:657 configuration.org:665
 #, no-wrap
 msgid "felis"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:646
+#: configuration.org:659
 msgid "https://git.natsukium.com/natsukium/felis"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:649
+#: configuration.org:662
 msgid "A terminal that redraws the boundary of what a terminal is responsible for"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:654
+#: configuration.org:667
 #, no-wrap
 msgid ""
 "felis = {\n"
@@ -1433,30 +1460,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:663 configuration.org:674
+#: configuration.org:676 configuration.org:687
 #, no-wrap
 msgid "firefox-addons"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:665
+#: configuration.org:678
 msgid "https://gitlab.com/rycee/nur-expressions"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:668
+#: configuration.org:681
 msgid "A few Nix expressions suitable for inclusion in Nix User Repository"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:671
+#: configuration.org:684
 msgid ""
 "Firefox/browser extensions packaged for Nix. Allows declarative browser "
 "extension management through home-manager."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:676
+#: configuration.org:689
 #, no-wrap
 msgid ""
 "firefox-addons = {\n"
@@ -1466,59 +1493,70 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:682 configuration.org:693
+#: configuration.org:695 configuration.org:711
 #, no-wrap
 msgid "hermes-agent"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:684
+#: configuration.org:697
 msgid "https://github.com/NousResearch/hermes-agent"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:687
+#: configuration.org:700
 msgid "The self-improving AI agent built by Nous Research"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:690
+#: configuration.org:703
 msgid ""
 "Provides the upstream NixOS module (=nixosModules.default=) and packaged "
 "Python build of hermes-agent."
 msgstr ""
 
+#. type: paragraph
+#: configuration.org:706
+msgid ""
+"The URL points at my fork: upstream reads =package.json=, =pyproject.toml= "
+"and =uv.lock= out of =builtins.path= copies that only materialise under a "
+"writable store, so the =nix flake check --no-build= CI runs fails with =path "
+"'...-hermes-python-source' is not valid=. Back to upstream once "
+"[[https://github.com/NousResearch/hermes-agent/pull/71228][PR #71228]] "
+"merges."
+msgstr ""
+
 #. type: paragraph in src
-#: configuration.org:695
+#: configuration.org:713
 #, no-wrap
 msgid ""
 "hermes-agent = {\n"
-"  url = \"github:NousResearch/hermes-agent\";\n"
+"  url = \"github:natsukium/hermes-agent/fix/nix-read-only-eval\";\n"
 "  inputs.flake-parts.follows = \"flake-parts\";\n"
 "  inputs.nixpkgs.follows = \"nixpkgs\";\n"
 "};"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:702 configuration.org:714
+#: configuration.org:720 configuration.org:732
 #, no-wrap
 msgid "mcp-servers"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:704
+#: configuration.org:722
 msgid "https://github.com/natsukium/mcp-servers-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:707
+#: configuration.org:725
 msgid ""
 "A Nix-based configuration framework for Model Control Protocol (MCP) servers "
 "with ready-to-use packages."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:710
+#: configuration.org:728
 msgid ""
 "Provides both a configuration framework and packaged MCP servers for Nix.  "
 "Used with Claude Code and other MCP-compatible AI assistants.  See [[*MCP "
@@ -1526,7 +1564,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:716
+#: configuration.org:734
 #, no-wrap
 msgid ""
 "mcp-servers = {\n"
@@ -1536,30 +1574,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:722 configuration.org:733
+#: configuration.org:740 configuration.org:751
 #, no-wrap
 msgid "niri-flake"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:724
+#: configuration.org:742
 msgid "https://github.com/sodiboo/niri-flake"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:727
+#: configuration.org:745
 msgid "Nix-native configuration for niri"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:730
+#: configuration.org:748
 msgid ""
 "Niri is a scrollable-tiling Wayland compositor. This flake provides the "
 "compositor and related modules for NixOS/home-manager integration."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:735
+#: configuration.org:753
 #, no-wrap
 msgid ""
 "niri-flake = {\n"
@@ -1574,24 +1612,24 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:746 configuration.org:752
+#: configuration.org:764 configuration.org:770
 #: modules/features/emacs/init.org:792
 #, no-wrap
 msgid "org-clickup"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:748
+#: configuration.org:766
 msgid "https://git.natsukium.com/natsukium/org-clickup"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:750
+#: configuration.org:768
 msgid "Emacs package for bidirectional ClickUp ↔ org-mode sync."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:754
+#: configuration.org:772
 #, no-wrap
 msgid ""
 "org-clickup = {\n"
@@ -1601,25 +1639,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:760 configuration.org:767
+#: configuration.org:778 configuration.org:785
 #, no-wrap
 msgid "nur-packages"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:762
+#: configuration.org:780
 msgid "https://github.com/natsukium/nur-packages"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:764
+#: configuration.org:782
 msgid ""
 "Personal NUR (Nix User Repository). Contains packages maintained personally "
 "that are either too niche for nixpkgs or require customizations."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:769
+#: configuration.org:787
 #, no-wrap
 msgid ""
 "nur-packages = {\n"
@@ -1629,25 +1667,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:775 configuration.org:793
+#: configuration.org:793 configuration.org:811
 #, no-wrap
 msgid "paneru"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:777
+#: configuration.org:795
 msgid ""
 "https://github.com/karinushka/paneru (fork: "
 "https://github.com/natsukium/paneru)"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:780
+#: configuration.org:798
 msgid "A sliding, tiling window manager for MacOS."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:783
+#: configuration.org:801
 msgid ""
 "Paneru brings the Niri-style scrollable tiling workflow used on Linux "
 "machines to macOS. Among the window managers tried for this purpose, it has "
@@ -1655,7 +1693,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:787
+#: configuration.org:805
 msgid ""
 "The =natsukium/paneru= fork exists for a single reason: upstream tiles Emacs "
 "child frames — the floating windows used by completion UIs such as Corfu — "
@@ -1666,7 +1704,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:795
+#: configuration.org:813
 #, no-wrap
 msgid ""
 "paneru = {\n"
@@ -1678,30 +1716,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:803 configuration.org:814
+#: configuration.org:821 configuration.org:832
 #, no-wrap
 msgid "simple-wol-manager"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:805
+#: configuration.org:823
 msgid "https://git.natsukium.com/natsukium/simple-wol-manager"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:808
+#: configuration.org:826
 msgid "A web-based application for managing Wake-on-LAN (WoL) devices"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:811
+#: configuration.org:829
 msgid ""
 "Personal Wake-on-LAN management tool. Provides a web interface for sending "
 "WoL packets and managing device configurations."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:816
+#: configuration.org:834
 #, no-wrap
 msgid ""
 "simple-wol-manager = {\n"
@@ -1711,23 +1749,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:822 configuration.org:835
+#: configuration.org:840 configuration.org:853
 #, no-wrap
 msgid "spoor"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:824
+#: configuration.org:842
 msgid "https://git.natsukium.com/natsukium/spoor"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:827
+#: configuration.org:845
 msgid "A standalone, terminal-agnostic hint picker for scrollback."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:830
+#: configuration.org:848
 msgid ""
 "My own take on tmux-thumbs' standalone mode: pipe text in, it labels the "
 "matches, and on selection it copies, opens, or runs a command with the "
@@ -1737,7 +1775,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:837
+#: configuration.org:855
 #, no-wrap
 msgid ""
 "spoor = {\n"
@@ -1748,28 +1786,28 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:844 configuration.org:854
+#: configuration.org:862 configuration.org:872
 #, no-wrap
 msgid "vicinae"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:846
+#: configuration.org:864
 msgid "https://github.com/vicinaehq/vicinae"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:849
+#: configuration.org:867
 msgid "A focused, keyboard-driven launcher for getting things done."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:852
+#: configuration.org:870
 msgid "Vicinae is a Raycast-style native launcher."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:856
+#: configuration.org:874
 #, no-wrap
 msgid ""
 "vicinae = {\n"
@@ -1779,30 +1817,30 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:862 configuration.org:873
+#: configuration.org:880 configuration.org:891
 #, no-wrap
 msgid "zen-browser"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:864
+#: configuration.org:882
 msgid "https://github.com/0xc000022070/zen-browser-flake"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:867
+#: configuration.org:885
 msgid "Community-driven Nix Flake for the Zen browser"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:870
+#: configuration.org:888
 msgid ""
 "Firefox-based browser focused on privacy. Community flake providing Nix "
 "packaging with home-manager integration."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:875
+#: configuration.org:893
 #, no-wrap
 msgid ""
 "zen-browser = {\n"
@@ -1813,13 +1851,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:883
+#: configuration.org:901
 #, no-wrap
 msgid "Nix Config"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:885
+#: configuration.org:903
 msgid ""
 "Nix settings used by this flake. While these settings are already configured "
 "on all managed machines, documenting them here helps with initial setup and "
@@ -1827,14 +1865,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:888
+#: configuration.org:906
 msgid ""
 "For detailed documentation on each setting, see "
 "https://nix.dev/manual/nix/latest/command-ref/conf-file.html"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:891
+#: configuration.org:909
 msgid ""
 "Note: =flake.nix= uses a restricted subset of the Nix language that prevents "
 "code reuse (see https://github.com/NixOS/nix/issues/4945). The values below "
@@ -1844,13 +1882,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:896 modules/configuration.org:172
+#: configuration.org:914 modules/configuration.org:172
 #, no-wrap
 msgid "Binary Caches"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:898
+#: configuration.org:916
 msgid ""
 "Binary cache (substituter) configuration for building this flake. While "
 "optional, configuring these caches significantly reduces build times by "
@@ -1858,7 +1896,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:902
+#: configuration.org:920
 msgid ""
 "Using =extra-substituters= and =extra-trusted-public-keys= instead of "
 "=substituters= and =trusted-public-keys= ensures this flake's cache "
@@ -1868,13 +1906,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:907 modules/configuration.org:82
+#: configuration.org:925 modules/configuration.org:82
 #, no-wrap
 msgid "nix-config"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:909
+#: configuration.org:927
 #, no-wrap
 msgid ""
 "extra-substituters = [\n"
@@ -1885,7 +1923,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:915
+#: configuration.org:933
 #, no-wrap
 msgid ""
 "extra-trusted-public-keys = [\n"
@@ -1896,13 +1934,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *****
-#: configuration.org:922
+#: configuration.org:940
 #, no-wrap
 msgid "cache.nixos-cuda.org"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:924
+#: configuration.org:942
 msgid ""
 "Binary cache for CUDA-related packages. These were distributed under the "
 "nix-community namespace before, and since November 2025 come from the CUDA "
@@ -1911,7 +1949,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:928
+#: configuration.org:946
 msgid ""
 "The nixos-cuda team describes this cache as being for development purposes "
 "only.  Alternatively, Flox's binary cache can be used for CUDA packages. As "
@@ -1921,13 +1959,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *****
-#: configuration.org:933
+#: configuration.org:951
 #, no-wrap
 msgid "natsukium.cachix.org"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:935
+#: configuration.org:953
 msgid ""
 "Personal binary cache containing outputs from this flake. Packages not "
 "available in the official =cache.nixos.org= are built on GitHub Actions and "
@@ -1935,13 +1973,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:938
+#: configuration.org:956
 #, no-wrap
 msgid "Hosts"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:940
+#: configuration.org:958
 msgid ""
 "An overview of the managed machines. Each host's full configuration lives in "
 "its own =hosts/<platform>/<name>/= directory, picked up by the loader in "
@@ -1949,45 +1987,45 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:946
+#: configuration.org:964
 msgid "Main laptop (M1 MacBook Air)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:950
+#: configuration.org:968
 msgid "Build server (M1 Mac mini)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:954
+#: configuration.org:972
 msgid "Laptop for work (M4 MacBook Pro)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:958
+#: configuration.org:976
 msgid "Main desktop (Intel Core i5-12400F)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:960 configuration.org:1030
+#: configuration.org:978 configuration.org:1048
 msgid ""
 "Wake-on-LAN (WoL) is enabled via the following BIOS setting: =Advanced > APM "
 "Configuration > Power On By PCI-E > Enabled="
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:965
+#: configuration.org:983
 msgid "WSL (dual boot with kilimanjaro)."
 msgstr ""
 
 #. type: heading *****
-#: configuration.org:967
+#: configuration.org:985
 #, no-wrap
 msgid "Setup"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:969
+#: configuration.org:987
 msgid ""
 "Setting up arusha requires both Windows-side and WSL-side steps. The process "
 "follows [[https://github.com/nix-community/NixOS-WSL][NixOS-WSL]]'s quick "
@@ -1995,49 +2033,49 @@ msgid ""
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:972
+#: configuration.org:990
 #, no-wrap
 msgid "Installing WSL"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:974
+#: configuration.org:992
 msgid ""
 "=--no-distribution= avoids installing the default Ubuntu distribution, which "
 "would just be removed after importing NixOS."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:978
+#: configuration.org:996
 #, no-wrap
 msgid "wsl --install --no-distribution"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:981
+#: configuration.org:999
 #, no-wrap
 msgid "Importing NixOS-WSL"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:983
+#: configuration.org:1001
 msgid "Download the latest NixOS-WSL release image and import it."
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:987
+#: configuration.org:1005
 #, no-wrap
 msgid "Select-Object -ExpandProperty assets `"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:988
+#: configuration.org:1006
 #, no-wrap
 msgid "Where-Object { $_.name -eq \"nixos.wsl\" } `"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:989
+#: configuration.org:1007
 #, no-wrap
 msgid ""
 "ForEach-Object { Invoke-WebRequest -Uri $_.browser_download_url -OutFile "
@@ -2045,7 +2083,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:986
+#: configuration.org:1004
 #, no-wrap
 msgid ""
 "Invoke-RestMethod -Uri "
@@ -2053,58 +2091,58 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:993
+#: configuration.org:1011
 #, no-wrap
 msgid "./nixos.wsl"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:996
+#: configuration.org:1014
 #, no-wrap
 msgid "Applying the configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:998
+#: configuration.org:1016
 msgid ""
 "After the initial NixOS-WSL boot, apply this flake's configuration directly "
 "from GitHub. No local clone is needed for the first run."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1002
+#: configuration.org:1020
 #, no-wrap
 msgid "wsl -d NixOS"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1006
+#: configuration.org:1024
 #, no-wrap
 msgid "sudo nixos-rebuild switch --flake github:natsukium/dotfiles#arusha"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:1009
+#: configuration.org:1027
 #, no-wrap
 msgid "Windows-side CLI tools"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1011
+#: configuration.org:1029
 msgid ""
 "Windows 24H2 includes a built-in =sudo= command, so =winget= can be elevated "
 "inline without a separate UAC prompt."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1016
+#: configuration.org:1034
 msgid ""
 "A mini PC with Intel N100, serving as a lightweight home server.  "
 "https://www.bee-link.com/products/beelink-mini-s12-pro-n100"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1019
+#: configuration.org:1037
 msgid ""
 "BIOS is configured with the following setting to automatically power on "
 "after an outage: =Chipset > PCH-IO Configuration > State After G3 > S0 "
@@ -2112,28 +2150,28 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1024
+#: configuration.org:1042
 msgid "Build server (OCI A1 Flex)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1028
+#: configuration.org:1046
 msgid "Build server (Ryzen 9 9950X)."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1035
+#: configuration.org:1053
 msgid "Phone (Pixel 7a)."
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1037
+#: configuration.org:1055
 #, no-wrap
 msgid "Outputs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1039
+#: configuration.org:1057
 msgid ""
 "Each per-system concern lives in its own =modules/per-system/*.nix= file, "
 "documented in =[[Per-system modules]]= below. The outputs body wires them "
@@ -2142,13 +2180,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:1043
+#: configuration.org:1061
 #, no-wrap
 msgid "outputs"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1045
+#: configuration.org:1063
 #, no-wrap
 msgid ""
 "systems = [\n"
@@ -2159,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1051
+#: configuration.org:1069
 #, no-wrap
 msgid ""
 "imports = [\n"
@@ -2168,7 +2206,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1055
+#: configuration.org:1073
 #, no-wrap
 msgid ""
 "flake = {\n"
@@ -2177,13 +2215,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1060
+#: configuration.org:1078
 #, no-wrap
 msgid "Per-system modules"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1062
+#: configuration.org:1080
 msgid ""
 "Per-concern flake-parts modules that each contribute to "
 "=perSystem=. Splitting them keeps =flake.nix= small and lets each concern "
@@ -2192,12 +2230,12 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1067
+#: configuration.org:1085
 msgid "The shared pattern is:"
 msgstr ""
 
 #. type: paragraph in SRC
-#: configuration.org:1070
+#: configuration.org:1088
 #, no-wrap
 msgid ""
 "{ ... }: # or { self, inputs, ... }: when the module needs them\n"
@@ -2211,20 +2249,20 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1080
+#: configuration.org:1098
 #, no-wrap
 msgid "Nixpkgs instance"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1082
+#: configuration.org:1100
 msgid ""
 "Constructs the per-system =pkgs= with overlays applied, exposed to all other "
 "=perSystem= consumers via =_module.args.pkgs=."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1085
+#: configuration.org:1103
 msgid ""
 "=allowUnfree= is enabled because several desktop hosts pull in unfree "
 "packages (NVIDIA drivers on =kilimanjaro=, =1password=, etc.) and gating "
@@ -2232,7 +2270,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1090
+#: configuration.org:1108
 #, no-wrap
 msgid ""
 "{ self, inputs, ... }:\n"
@@ -2251,13 +2289,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1104
+#: configuration.org:1122
 #, no-wrap
 msgid "Checks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1106
+#: configuration.org:1124
 msgid ""
 "Re-exports the NixOS VM tests under =./tests= as flake checks for the "
 "current system. Kept in its own module so the test wiring is easy to find "
@@ -2265,7 +2303,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1111
+#: configuration.org:1129
 #, no-wrap
 msgid ""
 "{ inputs, self, ... }:\n"
@@ -2282,18 +2320,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1124
+#: configuration.org:1142
 #, no-wrap
 msgid "Packages"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1126
+#: configuration.org:1144
 msgid "Per-system packages exposed as flake outputs."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1128
+#: configuration.org:1146
 msgid ""
 "The =html= package builds the published documentation "
 "([[*Documentation][Documentation]]). The build itself lives in "
@@ -2306,7 +2344,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1135
+#: configuration.org:1153
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -2344,7 +2382,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1167
+#: configuration.org:1185
 #, no-wrap
 msgid ""
 "            installPhase = ''\n"
@@ -2360,37 +2398,37 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1179
+#: configuration.org:1197
 #, no-wrap
 msgid "Overlays"
 msgstr ""
 
 #. type: keyword INCLUDE
-#: configuration.org:1180
+#: configuration.org:1198
 #, no-wrap
 msgid "\"./overlays/configuration.org\""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1182
+#: configuration.org:1200
 #, no-wrap
 msgid "Modules"
 msgstr ""
 
 #. type: keyword INCLUDE
-#: configuration.org:1183
+#: configuration.org:1201
 #, no-wrap
 msgid "\"./modules/configuration.org\""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1185
+#: configuration.org:1203
 #, no-wrap
 msgid "Scripts"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1187
+#: configuration.org:1205
 msgid ""
 "Scripts used in flake derivations, pre-commit hooks, and Makefile recipes.  "
 "Extracted to separate files for proper syntax highlighting and independent "
@@ -2398,7 +2436,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1190
+#: configuration.org:1208
 msgid ""
 "=org-to-html.el= drives the documentation export. Four choices shape "
 "it. First, htmlize emits =org-*= class names rather than inline colors, so "
@@ -2412,7 +2450,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1198
+#: configuration.org:1216
 msgid ""
 "Third, every code block that tangles is headed by a link to the file it "
 "produces.  Literate configuration only pays off if a reader can get from the "
@@ -2426,7 +2464,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1208
+#: configuration.org:1226
 msgid ""
 "Fourth, noweb references link to the block that defines them, and a "
 "referenced block is headed by its own name. A tangled file is assembled from "
@@ -2438,7 +2476,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1217
+#: configuration.org:1235
 #, no-wrap
 msgid ""
 "(require 'cl-lib)\n"
@@ -2449,7 +2487,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1223
+#: configuration.org:1241
 #, no-wrap
 msgid ""
 "(add-to-list 'org-src-lang-modes '(\"nix\" . nix-ts))\n"
@@ -2457,7 +2495,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1226
+#: configuration.org:1244
 #, no-wrap
 msgid ""
 ";; Emit `org-*' class names on syntax spans instead of inline color styles, "
@@ -2469,7 +2507,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1231
+#: configuration.org:1249
 #, no-wrap
 msgid ""
 ";; Export five headline levels as real headings (default is 3). Deeper "
@@ -2482,7 +2520,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1236
+#: configuration.org:1254
 #, no-wrap
 msgid ""
 ";; The frame styling is my own; drop Org's default <style> and scripts.\n"
@@ -2491,7 +2529,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1240
+#: configuration.org:1258
 #, no-wrap
 msgid ""
 ";; Don't abort the whole documentation build over one dangling link. The\n"
@@ -2504,7 +2542,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1247
+#: configuration.org:1265
 #, no-wrap
 msgid ""
 ";; Inline the stylesheet and script rather than <link>/<script src>-ing "
@@ -2522,7 +2560,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1257
+#: configuration.org:1275
 #, no-wrap
 msgid ""
 "(setq org-html-head\n"
@@ -2533,7 +2571,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1261
+#: configuration.org:1279
 #, no-wrap
 msgid ""
 ";; Fold the table of contents: rewrite Org's #table-of-contents <div> into "
@@ -2560,13 +2598,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1278
+#: configuration.org:1296
 #, no-wrap
 msgid "(add-to-list 'org-export-filter-final-output-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1281
+#: configuration.org:1299
 #, no-wrap
 msgid ""
 ";; Head every code block with the file it tangles to, linked to GitHub.\n"
@@ -2593,7 +2631,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1294
+#: configuration.org:1312
 #, no-wrap
 msgid ""
 ";; Documents that declare `:tangle' targets, and the prefix their paths "
@@ -2612,13 +2650,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1304
+#: configuration.org:1322
 #, no-wrap
 msgid "(defvar dotfiles-tangle-map nil)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1306
+#: configuration.org:1324
 #, no-wrap
 msgid ""
 "(defun dotfiles-src-block-target (src-block prefix)\n"
@@ -2645,7 +2683,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1322
+#: configuration.org:1340
 #, no-wrap
 msgid ""
 "(defun dotfiles-build-tangle-map (suffix)\n"
@@ -2679,7 +2717,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1344
+#: configuration.org:1362
 #, no-wrap
 msgid ""
 ";; Turn noweb references into links to the block that defines them, so the\n"
@@ -2690,7 +2728,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1349
+#: configuration.org:1367
 #, no-wrap
 msgid ""
 "(defun dotfiles-collect-noweb-names (tree _backend _info)\n"
@@ -2715,13 +2753,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1366 configuration.org:1544
+#: configuration.org:1384 configuration.org:1562
 #, no-wrap
 msgid "(add-to-list 'org-export-filter-parse-tree-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1369
+#: configuration.org:1387
 #, no-wrap
 msgid ""
 "(defconst dotfiles-noweb-token \"nowebref0%s0\"\n"
@@ -2729,7 +2767,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1372
+#: configuration.org:1390
 #, no-wrap
 msgid ""
 "(defun dotfiles-noweb-anchor (name)\n"
@@ -2743,7 +2781,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1379
+#: configuration.org:1397
 #, no-wrap
 msgid ""
 "(defun dotfiles-noweb-html (name)\n"
@@ -2756,7 +2794,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1386
+#: configuration.org:1404
 #, no-wrap
 msgid ""
 "(defun dotfiles-fontify-noweb (original code lang &rest args)\n"
@@ -2788,13 +2826,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1410
+#: configuration.org:1428
 #, no-wrap
 msgid "(advice-add 'org-html-fontify-code :around #'dotfiles-fontify-noweb)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1412
+#: configuration.org:1430
 #, no-wrap
 msgid ""
 "(defconst dotfiles-src-lang-names '((\"emacs-lisp\" . \"elisp\"))\n"
@@ -2802,7 +2840,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1415
+#: configuration.org:1433
 #, no-wrap
 msgid ""
 "(defconst dotfiles-src-container \"<div "
@@ -2810,7 +2848,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1417
+#: configuration.org:1435
 #, no-wrap
 msgid ""
 "(defun dotfiles-html-src-block-head (original src-block contents info)\n"
@@ -2850,13 +2888,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1448
+#: configuration.org:1466
 #, no-wrap
 msgid "(advice-add 'org-html-src-block :around #'dotfiles-html-src-block-head)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1450
+#: configuration.org:1468
 #, no-wrap
 msgid ""
 ";; Anchor headings by a slug of their title instead of the generated "
@@ -2875,7 +2913,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1459
+#: configuration.org:1477
 #, no-wrap
 msgid ""
 "(defun dotfiles-slugify (text)\n"
@@ -2889,7 +2927,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1467
+#: configuration.org:1485
 #, no-wrap
 msgid ""
 "(defun dotfiles-title-slug (headline)\n"
@@ -2902,7 +2940,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1475
+#: configuration.org:1493
 #, no-wrap
 msgid ""
 "(defun dotfiles-heading-slug (headline)\n"
@@ -2937,7 +2975,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1498
+#: configuration.org:1516
 #, no-wrap
 msgid ""
 ";; Slugs are assigned here, in one pass over the finished tree, rather than "
@@ -2956,7 +2994,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1507
+#: configuration.org:1525
 #, no-wrap
 msgid ""
 "(defvar dotfiles-translating nil\n"
@@ -2965,7 +3003,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1510
+#: configuration.org:1528
 #, no-wrap
 msgid ""
 "(defun dotfiles-assign-heading-slugs (tree _backend _info)\n"
@@ -3011,7 +3049,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1547
+#: configuration.org:1565
 #, no-wrap
 msgid ""
 "(defun dotfiles-export-get-reference (original datum info)\n"
@@ -3023,7 +3061,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1553
+#: configuration.org:1571
 #, no-wrap
 msgid ""
 "(advice-add 'org-export-get-reference :around "
@@ -3031,7 +3069,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1555
+#: configuration.org:1573
 #, no-wrap
 msgid ""
 ";; A heading is only linkable if the reader can get at its URL, so each one "
@@ -3060,13 +3098,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1575
+#: configuration.org:1593
 #, no-wrap
 msgid "(advice-add 'org-html-headline :around #'dotfiles-html-headline-anchor)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1577
+#: configuration.org:1595
 #, no-wrap
 msgid ""
 "(defun dotfiles-export-html (lang)\n"
@@ -3084,7 +3122,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1589
+#: configuration.org:1607
 #, no-wrap
 msgid ""
 ";; Which editions to export, set by scripts/build-html.sh. Building "
@@ -3098,7 +3136,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1596
+#: configuration.org:1614
 msgid ""
 "=build-html.sh= wraps that export so the same command produces the published "
 "site and a local preview. The build used to live in the Nix derivation, "
@@ -3109,7 +3147,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1603
+#: configuration.org:1621
 msgid ""
 "Emacs writes each page beside its source document, so the script moves the "
 "results into an output directory and deletes what Emacs left behind; kept "
@@ -3117,14 +3155,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1608 configuration.org:1666 configuration.org:1685
-#: configuration.org:1692
+#: configuration.org:1626 configuration.org:1684 configuration.org:1703
+#: configuration.org:1710
 #, no-wrap
 msgid "set -euo pipefail"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1610
+#: configuration.org:1628
 #, no-wrap
 msgid ""
 "output=build\n"
@@ -3132,7 +3170,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1613
+#: configuration.org:1631
 #, no-wrap
 msgid ""
 "while [ $# -gt 0 ]; do\n"
@@ -3154,13 +3192,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1630
+#: configuration.org:1648
 #, no-wrap
 msgid "cd \"$(dirname \"$0\")/..\""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1634
+#: configuration.org:1652
 #, no-wrap
 msgid ""
 "translations=$(tr ' ' '\\n' <<<\"$langs\" | grep -vx -e en -e '' | tr '\\n' "
@@ -3169,7 +3207,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1641
+#: configuration.org:1659
 #, no-wrap
 msgid ""
 "if [ -n \"$translations\" ]; then\n"
@@ -3178,13 +3216,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1645
+#: configuration.org:1663
 #, no-wrap
 msgid "DOTFILES_HTML_LANGS=\"$langs\" emacs --batch -l scripts/org-to-html.el"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1647
+#: configuration.org:1665
 #, no-wrap
 msgid ""
 "for lang in $langs; do\n"
@@ -3202,7 +3240,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1668
+#: configuration.org:1686
 #, no-wrap
 msgid ""
 "message=\"$1\"\n"
@@ -3210,13 +3248,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1671
+#: configuration.org:1689
 #, no-wrap
 msgid "changed=$(git diff --name-only \"$@\")"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1673
+#: configuration.org:1691
 #, no-wrap
 msgid ""
 "if [ -n \"$changed\" ]; then\n"
@@ -3231,7 +3269,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1687
+#: configuration.org:1705
 #, no-wrap
 msgid ""
 "po4a po4a.cfg\n"
@@ -3239,7 +3277,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1694
+#: configuration.org:1712
 #, no-wrap
 msgid ""
 "make -B tangle -j\n"
@@ -3247,7 +3285,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1699
+#: configuration.org:1717
 #, no-wrap
 msgid ""
 "(require 'ox-md)\n"
@@ -3256,7 +3294,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1704
+#: configuration.org:1722
 msgid ""
 "The =org-export-with-author= setting is explicitly disabled because "
 "=configuration.org= has no =#+AUTHOR:= keyword, so Org falls back to the "
@@ -3268,7 +3306,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1713
+#: configuration.org:1731
 #, no-wrap
 msgid ""
 "(require 'ox-org)\n"
@@ -3280,26 +3318,26 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: configuration.org:1721 .github/README.org:56
+#: configuration.org:1739 .github/README.org:56
 #, no-wrap
 msgid "Development"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1723 .github/README.org:58
+#: configuration.org:1741 .github/README.org:58
 msgid ""
 "This repository provides a Nix development shell with all the tools needed "
 "for working on the configurations. Enter the shell by running:"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1727 .github/README.org:62
+#: configuration.org:1745 .github/README.org:62
 #, no-wrap
 msgid "nix develop"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1730 .github/README.org:65
+#: configuration.org:1748 .github/README.org:65
 msgid ""
 "The shell includes infrastructure tools (Terraform, sops, ssh-to-age), "
 "translation tools (po4a, gettext), and build utilities (nix-fast-build).  On "
@@ -3308,7 +3346,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1736 .github/README.org:71
+#: configuration.org:1754 .github/README.org:71
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -3354,7 +3392,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1776 .github/README.org:111
+#: configuration.org:1794 .github/README.org:111
 #, no-wrap
 msgid ""
 "        terraform = pkgs.mkShell {\n"
@@ -3366,13 +3404,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1784 .github/README.org:118
+#: configuration.org:1802 .github/README.org:118
 #, no-wrap
 msgid "Pre-commit hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1786 .github/README.org:120
+#: configuration.org:1804 .github/README.org:120
 msgid ""
 "Hooks run by [[https://github.com/cachix/git-hooks.nix][git-hooks.nix]] on "
 "every commit. =prek= is used as the runner because it is the "
@@ -3381,7 +3419,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1790 .github/README.org:124
+#: configuration.org:1808 .github/README.org:124
 msgid ""
 "=check-org-tangle= is the only hook with =priority = 0= because it must run "
 "before everything else: if Org files are out of sync, formatters and linters "
@@ -3390,7 +3428,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1796 .github/README.org:130
+#: configuration.org:1814 .github/README.org:130
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3399,7 +3437,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1800 .github/README.org:134
+#: configuration.org:1818 .github/README.org:134
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -3517,13 +3555,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1910 .github/README.org:243
+#: configuration.org:1928 .github/README.org:243
 #, no-wrap
 msgid "Formatting"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1912 .github/README.org:245
+#: configuration.org:1930 .github/README.org:245
 msgid ""
 "Formatters are aggregated via "
 "[[https://github.com/numtide/treefmt-nix][treefmt-nix]] and invoked from the "
@@ -3532,7 +3570,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1917 .github/README.org:250
+#: configuration.org:1935 .github/README.org:250
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3541,7 +3579,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1921 .github/README.org:254
+#: configuration.org:1939 .github/README.org:254
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3562,13 +3600,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1938 .github/README.org:270
+#: configuration.org:1956 .github/README.org:270
 #, no-wrap
 msgid "MCP Servers"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1940 .github/README.org:272
+#: configuration.org:1958 .github/README.org:272
 msgid ""
 "Configuration for "
 "[[https://github.com/natsukium/mcp-servers-nix][mcp-servers-nix]], enabled "
@@ -3577,19 +3615,19 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1946 .github/README.org:278
+#: configuration.org:1964 .github/README.org:278
 #, no-wrap
 msgid "=nixos=: NixOS package/option search and Home Manager documentation"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1947 .github/README.org:279
+#: configuration.org:1965 .github/README.org:279
 #, no-wrap
 msgid "=terraform=: Terraform registry lookup for providers, modules, and policies"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1948 .github/README.org:280
+#: configuration.org:1966 .github/README.org:280
 #, no-wrap
 msgid ""
 "=grafana=: Query dashboards, datasources, and metrics from the home server's "
@@ -3597,19 +3635,19 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1944 .github/README.org:276
+#: configuration.org:1962 .github/README.org:276
 msgid "Enabled servers:"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1949 .github/README.org:281
+#: configuration.org:1967 .github/README.org:281
 msgid ""
 "The =passwordCommand= option retrieves secrets at runtime using =rbw= "
 "(Bitwarden CLI), avoiding plaintext credentials in the repository."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1953 .github/README.org:285
+#: configuration.org:1971 .github/README.org:285
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3618,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1957 .github/README.org:289
+#: configuration.org:1975 .github/README.org:289
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3648,35 +3686,35 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1983 .github/README.org:314
+#: configuration.org:2001 .github/README.org:314
 #, no-wrap
 msgid "Translation"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1985 .github/README.org:316
+#: configuration.org:2003 .github/README.org:316
 msgid "This project uses po4a to manage translations."
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1987 .github/README.org:317
+#: configuration.org:2005 .github/README.org:317
 #, no-wrap
 msgid "Requirements"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1989 .github/README.org:319
+#: configuration.org:2007 .github/README.org:319
 msgid "The required packages are included in the development shell."
 msgstr ""
 
 #. type: keyword name
-#: configuration.org:1991 .github/README.org:321
+#: configuration.org:2009 .github/README.org:321
 #, no-wrap
 msgid "translation-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1993 .github/README.org:323
+#: configuration.org:2011 .github/README.org:323
 #, no-wrap
 msgid ""
 "gettext\n"
@@ -3684,31 +3722,31 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1998 .github/README.org:328
+#: configuration.org:2016 .github/README.org:328
 #, no-wrap
 msgid "=gettext=: provides msgfmt and other internationalization utilities"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1999 .github/README.org:329
+#: configuration.org:2017 .github/README.org:329
 #, no-wrap
 msgid "=po4a=: po4a >= 0.74 is required for Org mode support."
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:2000 .github/README.org:329
+#: configuration.org:2018 .github/README.org:329
 #, no-wrap
 msgid "Translation workflow"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:2002 .github/README.org:331
+#: configuration.org:2020 .github/README.org:331
 #, no-wrap
 msgid "Create po4a configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2004 .github/README.org:333
+#: configuration.org:2022 .github/README.org:333
 msgid ""
 "Configure the target language, location for generated po files, and "
 "documents to translate as follows.  The =-k 0= option forces output of "
@@ -3717,7 +3755,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:2013 .github/README.org:342
+#: configuration.org:2031 .github/README.org:342
 #, no-wrap
 msgid ""
 "[po4a_langs] ja\n"
@@ -3735,18 +3773,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2023 .github/README.org:352
+#: configuration.org:2041 .github/README.org:352
 msgid "For detailed information about =po4a.cfg= configuration, see =man po4a=."
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:2025 .github/README.org:353
+#: configuration.org:2043 .github/README.org:353
 #, no-wrap
 msgid "Create/Update po"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2027 .github/README.org:355
+#: configuration.org:2045 .github/README.org:355
 msgid ""
 "When documents are updated and you need to create/update po files, run the "
 "following command.  This generates template (pot) and po files for each "
@@ -3754,32 +3792,32 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:2033 .github/README.org:361
+#: configuration.org:2051 .github/README.org:361
 #, no-wrap
 msgid "po4a --no-translations po4a.cfg"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:2036 .github/README.org:363
+#: configuration.org:2054 .github/README.org:363
 #, no-wrap
 msgid "Translate"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2038 .github/README.org:365
+#: configuration.org:2056 .github/README.org:365
 msgid ""
 "Edit the target language po using a po editor.  Popular options include "
 "Emacs po-mode, poedit, GNOME's Gtranslator, and KDE's Lokalize."
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:2045 .github/README.org:371
+#: configuration.org:2063 .github/README.org:371
 #, no-wrap
 msgid "Create/Update translation file"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2047 .github/README.org:373
+#: configuration.org:2065 .github/README.org:373
 msgid ""
 "After completing translations, generate files with the following command.  "
 "Since po files are also updated at this time, in practice you only need to "
@@ -3787,7 +3825,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:2053 .github/README.org:379
+#: configuration.org:2071 .github/README.org:379
 #, no-wrap
 msgid "po4a po4a.cfg"
 msgstr ""
@@ -6421,7 +6459,7 @@ msgstr ""
 #. type: paragraph
 #: overlays/configuration.org:14
 msgid ""
-"Overlays are organized into four categories based on their purpose and "
+"Overlays are organized into five categories based on their purpose and "
 "expected lifetime:"
 msgstr ""
 
@@ -6438,13 +6476,22 @@ msgstr ""
 #: overlays/configuration.org:20
 #, no-wrap
 msgid ""
+"*cuda*: Packages taken from the CUDA channel, the only revision whose CUDA "
+"builds are\n"
+"cached."
+msgstr ""
+
+#. type: plain list -
+#: overlays/configuration.org:22
+#, no-wrap
+msgid ""
 "*temporary-fix*: Local overrides (e.g., disabling tests) that don't require "
 "a different\n"
 "nixpkgs version. Remove once fixed upstream."
 msgstr ""
 
 #. type: plain list -
-#: overlays/configuration.org:21
+#: overlays/configuration.org:23
 #, no-wrap
 msgid ""
 "*pre-release*: Alpha, beta, or pre-release packages for testing before they "
@@ -6452,7 +6499,7 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: overlays/configuration.org:23
+#: overlays/configuration.org:25
 #, no-wrap
 msgid ""
 "*patches*: Workarounds not suitable for upstream contribution (e.g., "
@@ -6461,7 +6508,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:30
+#: overlays/configuration.org:32
 #, no-wrap
 msgid ""
 "{ inputs }:\n"
@@ -6470,19 +6517,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:34
+#: overlays/configuration.org:36
+#, no-wrap
+msgid "<<cuda>>"
+msgstr ""
+
+#. type: paragraph in src
+#: overlays/configuration.org:38
 #, no-wrap
 msgid "<<temporary-fix>>"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:36
+#: overlays/configuration.org:40
 #, no-wrap
 msgid "<<pre-release>>"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:38
+#: overlays/configuration.org:42
 #, no-wrap
 msgid ""
 "  <<patches>>\n"
@@ -6490,13 +6543,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:42 overlays/configuration.org:48
+#: overlays/configuration.org:46 overlays/configuration.org:52
 #, no-wrap
 msgid "stable"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:44
+#: overlays/configuration.org:48
 msgid ""
 "Fetch packages from nixpkgs-stable when broken in unstable. This includes "
 "cases where the upstream fix would trigger excessive rebuilds, or where the "
@@ -6504,7 +6557,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:50
+#: overlays/configuration.org:54
 #, no-wrap
 msgid ""
 "stable = final: prev: {\n"
@@ -6512,13 +6565,59 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:54 overlays/configuration.org:61
+#: overlays/configuration.org:58 overlays/configuration.org:68
+#, no-wrap
+msgid "cuda"
+msgstr ""
+
+#. type: paragraph
+#: overlays/configuration.org:60
+msgid ""
+"[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]] only covers the head "
+"of =nixos-unstable-cuda=, so kilimanjaro takes its CUDA packages from "
+"=nixpkgs-cuda=. Naming =ollama= and =handy= is enough: =onnxruntime=, "
+"=openvino=, =opencv= and =cudnn-frontend= are only reachable through them."
+msgstr ""
+
+#. type: paragraph
+#: overlays/configuration.org:64
+msgid ""
+"The package set is imported plain because the CUDA Hydra builds plain "
+"nixpkgs, and a local overlay reaching into that closure would move the store "
+"paths off the cache. The guard keeps the pin off hosts that leave "
+"=cudaSupport= unset."
+msgstr ""
+
+#. type: paragraph in src
+#: overlays/configuration.org:70
+#, no-wrap
+msgid ""
+"cuda =\n"
+"  final: prev:\n"
+"  prev.lib.optionalAttrs (prev.config.cudaSupport or false) (\n"
+"    let\n"
+"      pkgs = import inputs.nixpkgs-cuda {\n"
+"        inherit (prev.stdenv.hostPlatform) system;\n"
+"        config = {\n"
+"          cudaSupport = true;\n"
+"          allowUnfree = true;\n"
+"        };\n"
+"      };\n"
+"    in\n"
+"    {\n"
+"      inherit (pkgs) handy ollama;\n"
+"    }\n"
+"  );"
+msgstr ""
+
+#. type: keyword NAME
+#: overlays/configuration.org:88 overlays/configuration.org:95
 #, no-wrap
 msgid "temporary-fix"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:56
+#: overlays/configuration.org:90
 msgid ""
 "Local overrides for packages that build but have failing tests or minor "
 "issues.  Unlike the =stable= overlay, these don't require fetching packages "
@@ -6528,7 +6627,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:63
+#: overlays/configuration.org:97
 #, no-wrap
 msgid ""
 "temporary-fix = final: prev: {\n"
@@ -6537,18 +6636,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: overlays/configuration.org:68
+#: overlays/configuration.org:102
 #, no-wrap
 msgid "Python313 package set"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:70
+#: overlays/configuration.org:104
 msgid "Override problematic Python packages using =packageOverrides=."
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:72
+#: overlays/configuration.org:106
 msgid ""
 "Python packages in nixpkgs form an interconnected dependency graph. The "
 "=packageOverrides= mechanism ensures that when a package is overridden, all "
@@ -6559,7 +6658,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:78
+#: overlays/configuration.org:112
 msgid ""
 "See "
 "[[https://nixos.org/manual/nixpkgs/stable/#overriding-python-packages][nixpkgs "
@@ -6567,13 +6666,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:80
+#: overlays/configuration.org:114
 #, no-wrap
 msgid "python313-package-set"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:82
+#: overlays/configuration.org:116
 #, no-wrap
 msgid ""
 "python313 = prev.python313.override {\n"
@@ -6585,20 +6684,20 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:90 overlays/configuration.org:98
+#: overlays/configuration.org:124 overlays/configuration.org:132
 #, no-wrap
 msgid "rapidocr-onnxruntime"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:92
+#: overlays/configuration.org:126
 msgid ""
 "The test suite causes a segmentation fault during execution. The root cause "
 "is still under investigation."
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:95
+#: overlays/configuration.org:129
 msgid ""
 "This package is pulled in as a transitive dependency. Runtime functionality "
 "has been verified to work correctly in actual use, so disabling the test "
@@ -6606,7 +6705,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:100
+#: overlays/configuration.org:134
 #, no-wrap
 msgid ""
 "rapidocr-onnxruntime = pyprev.rapidocr-onnxruntime.overridePythonAttrs (_: "
@@ -6616,13 +6715,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:105 overlays/configuration.org:114
+#: overlays/configuration.org:139 overlays/configuration.org:148
 #, no-wrap
 msgid "lxml-html-clean"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:107
+#: overlays/configuration.org:141
 msgid ""
 "Tests fail due to breaking changes in libxml2 2.14, which modified how "
 "certain DOM operations handle whitespace and entity encoding. These changes "
@@ -6631,7 +6730,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:111
+#: overlays/configuration.org:145
 msgid ""
 "Tracked upstream in "
 "[[https://github.com/fedora-python/lxml_html_clean/issues/24][fedora-python/lxml_html_clean#24]].  "
@@ -6640,7 +6739,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:116
+#: overlays/configuration.org:150
 #, no-wrap
 msgid ""
 "lxml-html-clean = pyprev.lxml-html-clean.overridePythonAttrs (_: {\n"
@@ -6649,13 +6748,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:121 overlays/configuration.org:127
+#: overlays/configuration.org:155 overlays/configuration.org:161
 #, no-wrap
 msgid "pre-release"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:123
+#: overlays/configuration.org:157
 msgid ""
 "Overlay for testing alpha, beta, or pre-release versions of packages before "
 "they land in nixpkgs. Useful for evaluating release candidates, nightly "
@@ -6664,24 +6763,24 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:129
+#: overlays/configuration.org:163
 #, no-wrap
 msgid "pre-release = final: prev: { };"
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:132 overlays/configuration.org:141
+#: overlays/configuration.org:166 overlays/configuration.org:175
 #, no-wrap
 msgid "patches"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:134
+#: overlays/configuration.org:168
 msgid "Workarounds that are not suitable for upstream contribution."
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:136
+#: overlays/configuration.org:170
 msgid ""
 "These patches address issues that upstream would likely not accept—either "
 "because they are specific to this configuration (e.g., locale settings), "
@@ -6690,7 +6789,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:143
+#: overlays/configuration.org:177
 #, no-wrap
 msgid ""
 "patches = final: prev: {\n"
@@ -6700,13 +6799,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:149 overlays/configuration.org:162
+#: overlays/configuration.org:183 overlays/configuration.org:196
 #, no-wrap
 msgid "gh-dash"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:151
+#: overlays/configuration.org:185
 msgid ""
 "The preview pane renders incorrectly when =LANG=ja_JP.UTF-8= is set. The "
 "issue stems from gh-dash's terminal width calculation, which miscounts the "
@@ -6715,7 +6814,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:156
+#: overlays/configuration.org:190
 msgid ""
 "Setting =LANG=C.UTF-8= forces ASCII-compatible width calculations while "
 "preserving UTF-8 encoding support, which fixes the rendering issue. We use "
@@ -6724,14 +6823,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:160
+#: overlays/configuration.org:194
 msgid ""
 "Reported upstream in "
 "[[https://github.com/dlvhdr/gh-dash/issues/316][dlvhdr/gh-dash#316]]."
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:164
+#: overlays/configuration.org:198
 #, no-wrap
 msgid ""
 "gh-dash =\n"
@@ -6745,18 +6844,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: overlays/configuration.org:174
+#: overlays/configuration.org:208
 #, no-wrap
 msgid "mkShim"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:176
+#: overlays/configuration.org:210
 msgid "Shim utility for providing stub implementations of macOS Command Line Tools."
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:178
+#: overlays/configuration.org:212
 msgid ""
 "On darwin systems without Xcode Command Line Tools installed, invoking "
 "commands like =cc= or =python3= triggers an annoying system popup prompting "
@@ -6766,20 +6865,20 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:183
+#: overlays/configuration.org:217
 msgid ""
 "See [[file:../pkgs/mkShim/][pkgs/mkShim]] for the implementation details and "
 "list of shimmed commands."
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:185
+#: overlays/configuration.org:219
 #, no-wrap
 msgid "command-line-tools-shim"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:187
+#: overlays/configuration.org:221
 #, no-wrap
 msgid "inherit (final.callPackage ../pkgs/mkShim { }) mkShim commandLineToolsShim;"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-25 18:20+0900\n"
+"POT-Creation-Date: 2026-07-25 21:57+0900\n"
 "PO-Revision-Date: 2026-03-01 14:13+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -163,7 +163,7 @@ msgid "Role"
 msgstr "用途"
 
 #. type: cell column 0
-#: configuration.org:35 configuration.org:956 .github/README.org:28
+#: configuration.org:35 configuration.org:974 .github/README.org:28
 #, no-wrap
 msgid "kilimanjaro"
 msgstr ""
@@ -189,7 +189,7 @@ msgid "Main desktop"
 msgstr "メインデスクトップ"
 
 #. type: cell column 0
-#: configuration.org:36 configuration.org:1026 .github/README.org:29
+#: configuration.org:36 configuration.org:1044 .github/README.org:29
 #, no-wrap
 msgid "tarangire"
 msgstr ""
@@ -208,7 +208,7 @@ msgid "Build server"
 msgstr "ビルドサーバー"
 
 #. type: cell column 0
-#: configuration.org:37 configuration.org:1014 .github/README.org:30
+#: configuration.org:37 configuration.org:1032 .github/README.org:30
 #, no-wrap
 msgid "manyara"
 msgstr ""
@@ -226,7 +226,7 @@ msgid "Home server"
 msgstr "ホームサーバー"
 
 #. type: cell column 0
-#: configuration.org:38 configuration.org:963 .github/README.org:31
+#: configuration.org:38 configuration.org:981 .github/README.org:31
 #, no-wrap
 msgid "arusha"
 msgstr ""
@@ -244,7 +244,7 @@ msgid "WSL environment"
 msgstr "WSL環境"
 
 #. type: cell column 0
-#: configuration.org:39 configuration.org:1022 .github/README.org:32
+#: configuration.org:39 configuration.org:1040 .github/README.org:32
 #, no-wrap
 msgid "serengeti"
 msgstr ""
@@ -262,7 +262,7 @@ msgid "OCI A1 Flex"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:40 configuration.org:944 .github/README.org:33
+#: configuration.org:40 configuration.org:962 .github/README.org:33
 #, no-wrap
 msgid "katavi"
 msgstr ""
@@ -287,7 +287,7 @@ msgid "Main laptop"
 msgstr "メインラップトップ"
 
 #. type: cell column 0
-#: configuration.org:41 configuration.org:952 .github/README.org:34
+#: configuration.org:41 configuration.org:970 .github/README.org:34
 #, no-wrap
 msgid "work"
 msgstr ""
@@ -305,7 +305,7 @@ msgid "Work laptop"
 msgstr "仕事用ラップトップ"
 
 #. type: cell column 0
-#: configuration.org:42 configuration.org:948 .github/README.org:35
+#: configuration.org:42 configuration.org:966 .github/README.org:35
 #, no-wrap
 msgid "mikumi"
 msgstr ""
@@ -317,13 +317,13 @@ msgid "M1 Mac mini"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:43 configuration.org:1033 .github/README.org:36
+#: configuration.org:43 configuration.org:1051 .github/README.org:36
 #, no-wrap
 msgid "android"
 msgstr ""
 
 #. type: cell column 1
-#: configuration.org:43 configuration.org:288 configuration.org:299
+#: configuration.org:43 configuration.org:301 configuration.org:312
 #: .github/README.org:36
 #, no-wrap
 msgid "nix-on-droid"
@@ -469,6 +469,7 @@ msgid ""
 "inputs = {\n"
 "  <<nixpkgs>>\n"
 "  <<nixpkgs-stable>>\n"
+"  <<nixpkgs-cuda>>\n"
 "  <<flake-parts>>\n"
 "  <<flake-utils>>\n"
 "  <<darwin>>\n"
@@ -507,7 +508,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:134
+#: configuration.org:135
 #, no-wrap
 msgid ""
 "nixConfig = {\n"
@@ -516,7 +517,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:138
+#: configuration.org:139
 #, no-wrap
 msgid ""
 "  outputs =\n"
@@ -528,18 +529,18 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:146
+#: configuration.org:147
 #, no-wrap
 msgid "Inputs"
 msgstr "入力"
 
 #. type: paragraph
-#: configuration.org:148
+#: configuration.org:149
 msgid "External flake dependencies."
 msgstr "外部flake依存関係です。"
 
 #. type: paragraph
-#: configuration.org:150
+#: configuration.org:151
 msgid ""
 "To minimize evaluation time caused by dependency graph bloat, almost all "
 "flakes are configured to follow the same nixpkgs and other common inputs "
@@ -549,29 +550,29 @@ msgstr ""
 "一のnixpkgsや共通のinputをfollowするように設定しています。"
 
 #. type: heading ****
-#: configuration.org:153
+#: configuration.org:154
 #, no-wrap
 msgid "Core"
 msgstr "コア"
 
 #. type: keyword NAME
-#: configuration.org:155 configuration.org:174
+#: configuration.org:156 configuration.org:175
 #, no-wrap
 msgid "nixpkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:157
+#: configuration.org:158
 msgid "https://github.com/NixOS/nixpkgs"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:160
+#: configuration.org:161
 msgid "Nix Packages collection & NixOS"
 msgstr "Nixパッケージコレクション & NixOS"
 
 #. type: paragraph
-#: configuration.org:163
+#: configuration.org:164
 msgid ""
 "The primary package set. Using =nixos-unstable-small= instead of =nixos-"
 "unstable= for faster channel updates. The =-small= variant skips some less "
@@ -584,7 +585,7 @@ msgstr ""
 "つつ新しいパッケージバージョンをより早く取得できます。"
 
 #. type: paragraph
-#: configuration.org:167
+#: configuration.org:168
 msgid ""
 "For channel selection guidance, see https://nix.dev/concepts/faq.html#which-"
 "channel-branch-should-i-use"
@@ -593,12 +594,12 @@ msgstr ""
 "branch-should-i-use を参照してください。"
 
 #. type: paragraph
-#: configuration.org:169
+#: configuration.org:170
 msgid "Channel status can be checked at https://status.nixos.org/"
 msgstr "チャンネルの状態は https://status.nixos.org/ で確認できます。"
 
 #. type: paragraph
-#: configuration.org:171
+#: configuration.org:172
 msgid ""
 "Using =git+https://= with =shallow=1= instead of =github:= for slightly "
 "faster file extraction on large repositories like nixpkgs."
@@ -607,19 +608,19 @@ msgstr ""
 "=github:= の代わりに=git+https://= と =shallow=1= を使用しています。"
 
 #. type: paragraph in src
-#: configuration.org:176
+#: configuration.org:177
 #, no-wrap
 msgid "nixpkgs.url = \"git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-unstable-small\";"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:179 configuration.org:184
+#: configuration.org:180 configuration.org:185
 #, no-wrap
 msgid "nixpkgs-stable"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:181
+#: configuration.org:182
 msgid ""
 "Provides stable packages when unstable has build failures or regressions. "
 "Mainly used by the =stable= overlay (see [[file:overlays/configuration.org]"
@@ -631,35 +632,65 @@ msgstr ""
 "されています。"
 
 #. type: paragraph in src
-#: configuration.org:186
+#: configuration.org:187
 #, no-wrap
 msgid "nixpkgs-stable.url = \"git+https://github.com/nixos/nixpkgs?shallow=1&ref=nixos-26.05\";"
 msgstr ""
 
+#. type: keyword NAME
+#: configuration.org:190 configuration.org:197
+#, no-wrap
+msgid "nixpkgs-cuda"
+msgstr ""
+
+#. type: paragraph
+#: configuration.org:192
+msgid ""
+"kilimanjaro builds with =cudaSupport=, and those builds are only cached by "
+"[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]], for the revision at "
+"the head of =nixos-unstable-cuda=. That branch trails =nixos-unstable-"
+"small=, so the =cuda= overlay (see [[file:overlays/configuration.org]"
+"[overlays/configuration.org]]) takes =ollama= and =handy= from this input "
+"while the rest of the system follows the main one."
+msgstr ""
+"kilimanjaroは=cudaSupport=付きでビルドしており、そのビルド結果をキャッシュして"
+"いるのは[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]]だけで、対象は"
+"=nixos-unstable-cuda=の先端リビジョンに限られます。このブランチは"
+"=nixos-unstable-small=より遅れるため、=cuda= overlay"
+"（[[file:overlays/configuration.org][overlays/configuration.org]]参照）が"
+"=ollama=と=handy=をこのinputから取得し、システムの残りは主となるinputに追従し"
+"ます。"
+
+#. type: paragraph in src
+#: configuration.org:199
+#, no-wrap
+msgid "nixpkgs-cuda.url = \"git+https://github.com/nixos-cuda/nixpkgs?shallow=1&ref=nixos-unstable-cuda\";"
+msgstr ""
+
 #. type: heading ****
-#: configuration.org:189
+#: configuration.org:202
 #, no-wrap
 msgid "Flake Infrastructure"
 msgstr "Flakeインフラストラクチャー"
 
 #. type: keyword NAME
-#: configuration.org:191 configuration.org:202
+#: configuration.org:204 configuration.org:215
 #, no-wrap
 msgid "flake-parts"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:193
+#: configuration.org:206
 msgid "https://github.com/hercules-ci/flake-parts"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:196
+#: configuration.org:209
 msgid "Simplify Nix Flakes with the module system"
 msgstr "モジュールシステムによるNix Flakeの簡素化"
 
 #. type: paragraph
-#: configuration.org:199
+#: configuration.org:212
 msgid ""
 "Framework for organizing flake outputs. Provides module system for flakes, "
 "making complex configurations more maintainable through separation of "
@@ -669,7 +700,7 @@ msgstr ""
 "し、関心の分離によって複雑な設定の保守性を高めます。"
 
 #. type: paragraph in src
-#: configuration.org:204
+#: configuration.org:217
 #, no-wrap
 msgid ""
 "flake-parts = {\n"
@@ -679,29 +710,29 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:210
+#: configuration.org:223
 #, no-wrap
 msgid "Transitive Dependencies"
 msgstr "推移的依存関係"
 
 #. type: keyword NAME
-#: configuration.org:212 configuration.org:223
+#: configuration.org:225 configuration.org:236
 #, no-wrap
 msgid "flake-utils"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:214
+#: configuration.org:227
 msgid "https://github.com/numtide/flake-utils"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:217
+#: configuration.org:230
 msgid "Pure Nix flake utility functions"
 msgstr "純粋なNix flakeユーティリティ関数"
 
 #. type: paragraph
-#: configuration.org:220
+#: configuration.org:233
 msgid ""
 "Common flake utilities. Only used transitively via =follows= to unify the "
 "flake-utils version across inputs that depend on it."
@@ -710,35 +741,35 @@ msgstr ""
 "一するため、=follows= 経由の推移的な利用のみです。"
 
 #. type: paragraph in src
-#: configuration.org:225
+#: configuration.org:238
 #, no-wrap
 msgid "flake-utils.url = \"github:numtide/flake-utils\";"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:228
+#: configuration.org:241
 #, no-wrap
 msgid "System Configuration"
 msgstr "システム設定"
 
 #. type: keyword NAME
-#: configuration.org:230 configuration.org:241
+#: configuration.org:243 configuration.org:254
 #, no-wrap
 msgid "darwin"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:232
+#: configuration.org:245
 msgid "https://github.com/nix-darwin/nix-darwin"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:235
+#: configuration.org:248
 msgid "Manage your macOS using Nix"
 msgstr "Nixを使ったmacOSの管理"
 
 #. type: paragraph
-#: configuration.org:238
+#: configuration.org:251
 msgid ""
 "nix-darwin provides NixOS-style system configuration for macOS. Essential "
 "for managing macOS system settings, launchd services, and Homebrew "
@@ -748,7 +779,7 @@ msgstr ""
 "定、launchdサービス、Homebrewを宣言的に管理するために欠かせません。"
 
 #. type: paragraph in src
-#: configuration.org:243
+#: configuration.org:256
 #, no-wrap
 msgid ""
 "darwin = {\n"
@@ -758,23 +789,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:249 configuration.org:260
+#: configuration.org:262 configuration.org:273
 #, no-wrap
 msgid "home-manager"
 msgstr "home-manager"
 
 #. type: paragraph
-#: configuration.org:251
+#: configuration.org:264
 msgid "https://github.com/nix-community/home-manager"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:254
+#: configuration.org:267
 msgid "Manage a user environment using Nix"
 msgstr "Nixを使ったユーザー環境の管理"
 
 #. type: paragraph
-#: configuration.org:257
+#: configuration.org:270
 msgid ""
 "User environment management. Manages dotfiles, user services, and per-user "
 "packages declaratively. The backbone of user-level configuration in this "
@@ -785,7 +816,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph in src
-#: configuration.org:262
+#: configuration.org:275
 #, no-wrap
 msgid ""
 "home-manager = {\n"
@@ -795,23 +826,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:268 configuration.org:279
+#: configuration.org:281 configuration.org:292
 #, no-wrap
 msgid "nixos-wsl"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:270
+#: configuration.org:283
 msgid "https://github.com/nix-community/nixos-wsl"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:273
+#: configuration.org:286
 msgid "NixOS on WSL"
 msgstr "WSL上のNixOS"
 
 #. type: paragraph
-#: configuration.org:276
+#: configuration.org:289
 msgid ""
 "NixOS on Windows Subsystem for Linux. Provides NixOS experience within WSL2, "
 "useful for Windows machines that need Linux development environments."
@@ -820,7 +851,7 @@ msgstr ""
 "開発環境が必要なWindowsマシンで活用できます。"
 
 #. type: paragraph in src
-#: configuration.org:281
+#: configuration.org:294
 #, no-wrap
 msgid ""
 "nixos-wsl = {\n"
@@ -831,17 +862,17 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:290
+#: configuration.org:303
 msgid "https://github.com/nix-community/nix-on-droid"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:293
+#: configuration.org:306
 msgid "Nix-enabled environment for your Android device."
 msgstr "AndroidデバイスのためのNix対応環境"
 
 #. type: paragraph
-#: configuration.org:296
+#: configuration.org:309
 msgid ""
 "Nix environment for Android via Termux. Enables the same declarative "
 "configuration approach on mobile devices."
@@ -850,7 +881,7 @@ msgstr ""
 "プローチを利用できます。"
 
 #. type: paragraph in src
-#: configuration.org:301
+#: configuration.org:314
 #, no-wrap
 msgid ""
 "nix-on-droid = {\n"
@@ -865,23 +896,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:312 configuration.org:323
+#: configuration.org:325 configuration.org:336
 #, no-wrap
 msgid "disko"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:314
+#: configuration.org:327
 msgid "https://github.com/nix-community/disko"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:317
+#: configuration.org:330
 msgid "Declarative disk partitioning and formatting using nix"
 msgstr "Nixを使った宣言的なディスクパーティショニングとフォーマット"
 
 #. type: paragraph
-#: configuration.org:320
+#: configuration.org:333
 msgid ""
 "Used for reproducible NixOS installations with automated partition layout, "
 "filesystem creation, and encryption setup."
@@ -890,7 +921,7 @@ msgstr ""
 "イルシステムの作成、暗号化のセットアップを自動化します。"
 
 #. type: paragraph in src
-#: configuration.org:325
+#: configuration.org:338
 #, no-wrap
 msgid ""
 "disko = {\n"
@@ -900,18 +931,18 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:331 configuration.org:342
+#: configuration.org:344 configuration.org:355
 #, no-wrap
 msgid "impermanence"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:333
+#: configuration.org:346
 msgid "https://github.com/nix-community/impermanence"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:336
+#: configuration.org:349
 msgid ""
 "Modules to help you handle persistent state on systems with ephemeral root "
 "storage"
@@ -920,7 +951,7 @@ msgstr ""
 "ル"
 
 #. type: paragraph
-#: configuration.org:339
+#: configuration.org:352
 msgid ""
 "Manages stateful paths on systems with ephemeral root filesystems. Used with "
 "btrfs snapshots to ensure only explicitly declared state persists across "
@@ -931,29 +962,29 @@ msgstr ""
 "も保持されるようにします。"
 
 #. type: paragraph in src
-#: configuration.org:344
+#: configuration.org:357
 #, no-wrap
 msgid "impermanence.url = \"github:nix-community/impermanence\";"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:347 configuration.org:357
+#: configuration.org:360 configuration.org:370
 #, no-wrap
 msgid "lanzaboote"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:349
+#: configuration.org:362
 msgid "https://github.com/nix-community/lanzaboote"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:352
+#: configuration.org:365
 msgid "Secure Boot for NixOS"
 msgstr "NixOS向けSecure Boot"
 
 #. type: paragraph
-#: configuration.org:355
+#: configuration.org:368
 msgid ""
 "Signs boot components with custom keys, enabling Secure Boot on NixOS "
 "machines."
@@ -962,7 +993,7 @@ msgstr ""
 "します。"
 
 #. type: paragraph in src
-#: configuration.org:359
+#: configuration.org:372
 #, no-wrap
 msgid ""
 "lanzaboote = {\n"
@@ -973,23 +1004,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:366 configuration.org:377
+#: configuration.org:379 configuration.org:390
 #, no-wrap
 msgid "nixos-facter-modules"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:368
+#: configuration.org:381
 msgid "https://github.com/numtide/nixos-facter-modules"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:371
+#: configuration.org:384
 msgid "A series of NixOS modules to be used in conjunction with nixos-facter"
 msgstr "nixos-facterと組み合わせて使用するNixOSモジュール群"
 
 #. type: paragraph
-#: configuration.org:374
+#: configuration.org:387
 msgid ""
 "Hardware detection for NixOS. Automatically generates hardware configuration "
 "based on detected hardware, simplifying initial system setup."
@@ -998,35 +1029,35 @@ msgstr ""
 "ウェア設定を自動生成し、初期システムセットアップを簡素化します。"
 
 #. type: paragraph in src
-#: configuration.org:379
+#: configuration.org:392
 #, no-wrap
 msgid "nixos-facter-modules.url = \"github:numtide/nixos-facter-modules\";"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:382
+#: configuration.org:395
 #, no-wrap
 msgid "Infrastructure"
 msgstr "インフラストラクチャー"
 
 #. type: keyword NAME
-#: configuration.org:384 configuration.org:395
+#: configuration.org:397 configuration.org:408
 #, no-wrap
 msgid "comin"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:386
+#: configuration.org:399
 msgid "https://github.com/nlewo/comin"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:389
+#: configuration.org:402
 msgid "GitOps For NixOS Machines"
 msgstr "NixOSマシンのためのGitOps"
 
 #. type: paragraph
-#: configuration.org:392
+#: configuration.org:405
 msgid ""
 "Automatically deploys configuration changes when pushed to the repository, "
 "enabling continuous deployment for servers without manual =nixos-rebuild "
@@ -1036,7 +1067,7 @@ msgstr ""
 "switch= を実行せずにサーバーの継続的デプロイメントを実現します。"
 
 #. type: paragraph in src
-#: configuration.org:397
+#: configuration.org:410
 #, no-wrap
 msgid ""
 "comin = {\n"
@@ -1046,25 +1077,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:403 configuration.org:418
+#: configuration.org:416 configuration.org:431
 #, no-wrap
 msgid "microvm"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:405
+#: configuration.org:418
 msgid "https://github.com/astro/microvm.nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:408
+#: configuration.org:421
 msgid ""
 "NixOS modules for declaring & running virtual machines from within your "
 "system Flake configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:411
+#: configuration.org:424
 msgid ""
 "Lightweight per-VM isolation suitable for running somewhat untrusted code.  "
 "Used to sandbox third-party agent code (hermes-agent) so crashes, runaway "
@@ -1075,7 +1106,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:420
+#: configuration.org:433
 #, no-wrap
 msgid ""
 "microvm = {\n"
@@ -1085,23 +1116,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:426 configuration.org:437
+#: configuration.org:439 configuration.org:450
 #, no-wrap
 msgid "sops-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:428
+#: configuration.org:441
 msgid "https://github.com/Mic92/sops-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:431
+#: configuration.org:444
 msgid "Atomic secret provisioning for NixOS based on sops"
 msgstr "sopsベースのNixOS向けアトミックなシークレットプロビジョニング"
 
 #. type: paragraph
-#: configuration.org:434
+#: configuration.org:447
 msgid ""
 "Secrets management using Mozilla SOPS. Encrypts secrets in the repository "
 "that are decrypted at activation time using age keys."
@@ -1110,7 +1141,7 @@ msgstr ""
 "し、アクティベーション時にageキーで復号します。"
 
 #. type: paragraph in src
-#: configuration.org:439
+#: configuration.org:452
 #, no-wrap
 msgid ""
 "sops-nix = {\n"
@@ -1120,18 +1151,18 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:445 configuration.org:456
+#: configuration.org:458 configuration.org:469
 #, no-wrap
 msgid "tsnsrv"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:447
+#: configuration.org:460
 msgid "https://github.com/boinkor-net/tsnsrv"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:450
+#: configuration.org:463
 msgid ""
 "A reverse proxy that exposes services on your tailnet (as their own "
 "tailscale participants)"
@@ -1140,7 +1171,7 @@ msgstr ""
 "て）"
 
 #. type: paragraph
-#: configuration.org:453
+#: configuration.org:466
 msgid ""
 "Tailscale service proxy. Exposes local services to the Tailscale network "
 "with automatic HTTPS certificates."
@@ -1149,7 +1180,7 @@ msgstr ""
 "Tailscaleネットワークに公開します。"
 
 #. type: paragraph in src
-#: configuration.org:458
+#: configuration.org:471
 #, no-wrap
 msgid ""
 "tsnsrv = {\n"
@@ -1160,23 +1191,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:465 configuration.org:481
+#: configuration.org:478 configuration.org:494
 #, no-wrap
 msgid "niks3"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:467
+#: configuration.org:480
 msgid "https://github.com/Mic92/niks3"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:470
+#: configuration.org:483
 msgid "S3-backed Nix binary cache with garbage collection"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:473
+#: configuration.org:486
 msgid ""
 "niks3 is a self-hosted, S3-backed Nix binary cache that resolves the upload "
 "limits I ran into with the alternatives: it hands clients presigned S3 URLs "
@@ -1189,7 +1220,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:483
+#: configuration.org:496
 #, no-wrap
 msgid ""
 "niks3 = {\n"
@@ -1200,29 +1231,29 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:490
+#: configuration.org:503
 #, no-wrap
 msgid "Development Tools"
 msgstr "開発ツール"
 
 #. type: keyword NAME
-#: configuration.org:492 configuration.org:505
+#: configuration.org:505 configuration.org:518
 #, no-wrap
 msgid "git-hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:494
+#: configuration.org:507
 msgid "https://github.com/cachix/git-hooks.nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:497
+#: configuration.org:510
 msgid "Seamless integration of pre-commit.com git hooks with Nix."
 msgstr "pre-commit.comのGitフックとNixのシームレスな統合"
 
 #. type: paragraph
-#: configuration.org:500
+#: configuration.org:513
 msgid ""
 "Pre-commit hooks as Nix derivations. Ensures code quality checks run "
 "consistently across all development environments without requiring global "
@@ -1233,7 +1264,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph
-#: configuration.org:503
+#: configuration.org:516
 msgid ""
 "Inputs that don't affect this flake are removed to prevent lockfile bloat."
 msgstr ""
@@ -1241,7 +1272,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph in src
-#: configuration.org:507
+#: configuration.org:520
 #, no-wrap
 msgid ""
 "git-hooks = {\n"
@@ -1253,23 +1284,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:515 configuration.org:526
+#: configuration.org:528 configuration.org:539
 #, no-wrap
 msgid "treefmt-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:517
+#: configuration.org:530
 msgid "https://github.com/numtide/treefmt-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:520
+#: configuration.org:533
 msgid "treefmt nix configuration"
 msgstr "treefmt-nixの設定"
 
 #. type: paragraph
-#: configuration.org:523
+#: configuration.org:536
 #, fuzzy
 #| msgid ""
 #| "Unified code formatter configuration. Runs multiple formatters (nixfmt, "
@@ -1285,7 +1316,7 @@ msgstr ""
 "保証します。"
 
 #. type: paragraph in src
-#: configuration.org:528
+#: configuration.org:541
 #, no-wrap
 msgid ""
 "treefmt-nix = {\n"
@@ -1295,29 +1326,29 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:534
+#: configuration.org:547
 #, no-wrap
 msgid "Desktop & Theming"
 msgstr "デスクトップ & テーマ"
 
 #. type: keyword NAME
-#: configuration.org:536 configuration.org:547
+#: configuration.org:549 configuration.org:560
 #, no-wrap
 msgid "nix-colors"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:538
+#: configuration.org:551
 msgid "https://github.com/misterio77/nix-colors"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:541
+#: configuration.org:554
 msgid "Modules and schemes to make theming with Nix awesome."
 msgstr "Nixでのテーマ設定を素晴らしくするモジュールとスキーム"
 
 #. type: paragraph
-#: configuration.org:544
+#: configuration.org:557
 msgid ""
 "Base16 color scheme framework for Nix. Provides consistent theming across "
 "applications through a single color scheme definition."
@@ -1326,7 +1357,7 @@ msgstr ""
 "り、アプリケーション間で一貫したテーマを提供します。"
 
 #. type: paragraph in src
-#: configuration.org:549
+#: configuration.org:562
 #, no-wrap
 msgid ""
 "nix-colors = {\n"
@@ -1336,23 +1367,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:555 configuration.org:566
+#: configuration.org:568 configuration.org:579
 #, no-wrap
 msgid "nix-wallpaper"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:557
+#: configuration.org:570
 msgid "https://github.com/natsukium/nix-wallpaper"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:560
+#: configuration.org:573
 msgid "A configurable wallpaper for nix systems"
 msgstr "Nixシステム向けのカスタマイズ可能な壁紙"
 
 #. type: paragraph
-#: configuration.org:563
+#: configuration.org:576
 msgid ""
 "Generates Nix logo wallpapers. Using a custom branch (=custom-logo=) that "
 "supports additional logo variants."
@@ -1361,7 +1392,7 @@ msgstr ""
 "ンチ（=custom-logo=）を使用しています。"
 
 #. type: paragraph in src
-#: configuration.org:568
+#: configuration.org:581
 #, no-wrap
 msgid ""
 "nix-wallpaper = {\n"
@@ -1373,31 +1404,31 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:576
+#: configuration.org:589
 #, no-wrap
 msgid "Applications"
 msgstr "アプリケーション"
 
 #. type: keyword NAME
-#: configuration.org:578 configuration.org:592
+#: configuration.org:591 configuration.org:605
 #, no-wrap
 msgid "brew-nix"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:580
+#: configuration.org:593
 msgid "https://github.com/BatteredBunny/brew-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:583
+#: configuration.org:596
 msgid ""
 "Experimental nix expression to package all MacOS casks from homebrew "
 "automatically"
 msgstr "HomebrewのすべてのmacOS caskを自動的にパッケージ化する実験的なNix式"
 
 #. type: paragraph
-#: configuration.org:586
+#: configuration.org:599
 msgid ""
 "Provides Homebrew casks as Nix packages for darwin. Useful for proprietary "
 "macOS applications not available in nixpkgs."
@@ -1406,7 +1437,7 @@ msgstr ""
 "イエタリなmacOSアプリケーションに便利です。"
 
 #. type: paragraph
-#: configuration.org:589
+#: configuration.org:602
 msgid ""
 "The =brew-api= input is marked as non-flake because it's just a data source "
 "(JSON API dump from Homebrew's API)."
@@ -1415,7 +1446,7 @@ msgstr ""
 "ため、non-flakeとしてマークされています。"
 
 #. type: paragraph in src
-#: configuration.org:594
+#: configuration.org:607
 #, no-wrap
 msgid ""
 "brew-api = {\n"
@@ -1431,18 +1462,18 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:606 configuration.org:614
+#: configuration.org:619 configuration.org:627
 #, no-wrap
 msgid "edgepkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:608
+#: configuration.org:621
 msgid "https://github.com/natsukium/edgepkgs"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:610
+#: configuration.org:623
 msgid ""
 "Personal repository for bleeding-edge packages. Contains packages not yet in "
 "nixpkgs, those requiring modifications, or packages that wouldn't be "
@@ -1453,7 +1484,7 @@ msgstr ""
 "トウェアや実験的なソフトウェアなど）を含みます。"
 
 #. type: paragraph in src
-#: configuration.org:616
+#: configuration.org:629
 #, no-wrap
 msgid ""
 "edgepkgs = {\n"
@@ -1463,23 +1494,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:622 configuration.org:635
+#: configuration.org:635 configuration.org:648
 #, no-wrap
 msgid "emacs-overlay"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:624
+#: configuration.org:637
 msgid "https://github.com/nix-community/emacs-overlay"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:627
+#: configuration.org:640
 msgid "Bleeding edge emacs overlay"
 msgstr "最新版Emacs overlay"
 
 #. type: paragraph
-#: configuration.org:630
+#: configuration.org:643
 msgid ""
 "Provides latest Emacs builds including native compilation and pure GTK "
 "variants.  Also includes MELPA packages updated more frequently than "
@@ -1491,7 +1522,7 @@ msgstr ""
 "して依存パッケージを自動設定するユーティリティのために使用しています。"
 
 #. type: paragraph in src
-#: configuration.org:637
+#: configuration.org:650
 #, no-wrap
 msgid ""
 "emacs-overlay = {\n"
@@ -1502,24 +1533,24 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:644 configuration.org:652
+#: configuration.org:657 configuration.org:665
 #, no-wrap
 msgid "felis"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:646
+#: configuration.org:659
 msgid "https://git.natsukium.com/natsukium/felis"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:649
+#: configuration.org:662
 msgid ""
 "A terminal that redraws the boundary of what a terminal is responsible for"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:654
+#: configuration.org:667
 #, no-wrap
 msgid ""
 "felis = {\n"
@@ -1532,23 +1563,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:663 configuration.org:674
+#: configuration.org:676 configuration.org:687
 #, no-wrap
 msgid "firefox-addons"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:665
+#: configuration.org:678
 msgid "https://gitlab.com/rycee/nur-expressions"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:668
+#: configuration.org:681
 msgid "A few Nix expressions suitable for inclusion in Nix User Repository"
 msgstr "Nix User Repositoryへの組み込みに適したNix式"
 
 #. type: paragraph
-#: configuration.org:671
+#: configuration.org:684
 msgid ""
 "Firefox/browser extensions packaged for Nix. Allows declarative browser "
 "extension management through home-manager."
@@ -1557,7 +1588,7 @@ msgstr ""
 "宣言的なブラウザ拡張機能管理が可能になります。"
 
 #. type: paragraph in src
-#: configuration.org:676
+#: configuration.org:689
 #, no-wrap
 msgid ""
 "firefox-addons = {\n"
@@ -1567,52 +1598,68 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:682 configuration.org:693
+#: configuration.org:695 configuration.org:711
 #, no-wrap
 msgid "hermes-agent"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:684
+#: configuration.org:697
 msgid "https://github.com/NousResearch/hermes-agent"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:687
+#: configuration.org:700
 msgid "The self-improving AI agent built by Nous Research"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:690
+#: configuration.org:703
 msgid ""
 "Provides the upstream NixOS module (=nixosModules.default=) and packaged "
 "Python build of hermes-agent."
 msgstr ""
 
+#. type: paragraph
+#: configuration.org:706
+msgid ""
+"The URL points at my fork: upstream reads =package.json=, =pyproject.toml= "
+"and =uv.lock= out of =builtins.path= copies that only materialise under a "
+"writable store, so the =nix flake check --no-build= CI runs fails with =path "
+"'...-hermes-python-source' is not valid=. Back to upstream once [[https://"
+"github.com/NousResearch/hermes-agent/pull/71228][PR #71228]] merges."
+msgstr ""
+"URLは自分のforkを指しています。upstreamは=package.json=、=pyproject.toml=、"
+"=uv.lock=を=builtins.path=によるコピーから読んでおり、そのコピーは書き込み可能"
+"なstoreでしか実体化しないため、CIが実行する=nix flake check --no-build=は"
+"=path '...-hermes-python-source' is not valid=で失敗します。[[https://github."
+"com/NousResearch/hermes-agent/pull/71228][PR #71228]]がマージされたらupstream"
+"に戻します。"
+
 #. type: paragraph in src
-#: configuration.org:695
+#: configuration.org:713
 #, no-wrap
 msgid ""
 "hermes-agent = {\n"
-"  url = \"github:NousResearch/hermes-agent\";\n"
+"  url = \"github:natsukium/hermes-agent/fix/nix-read-only-eval\";\n"
 "  inputs.flake-parts.follows = \"flake-parts\";\n"
 "  inputs.nixpkgs.follows = \"nixpkgs\";\n"
 "};"
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:702 configuration.org:714
+#: configuration.org:720 configuration.org:732
 #, no-wrap
 msgid "mcp-servers"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:704
+#: configuration.org:722
 msgid "https://github.com/natsukium/mcp-servers-nix"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:707
+#: configuration.org:725
 msgid ""
 "A Nix-based configuration framework for Model Control Protocol (MCP) servers "
 "with ready-to-use packages."
@@ -1621,7 +1668,7 @@ msgstr ""
 "ス設定フレームワーク"
 
 #. type: paragraph
-#: configuration.org:710
+#: configuration.org:728
 msgid ""
 "Provides both a configuration framework and packaged MCP servers for Nix.  "
 "Used with Claude Code and other MCP-compatible AI assistants.  See [[*MCP "
@@ -1632,7 +1679,7 @@ msgstr ""
 "[[*MCPサーバー][MCP Servers]]を参照してください。"
 
 #. type: paragraph in src
-#: configuration.org:716
+#: configuration.org:734
 #, no-wrap
 msgid ""
 "mcp-servers = {\n"
@@ -1642,23 +1689,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:722 configuration.org:733
+#: configuration.org:740 configuration.org:751
 #, no-wrap
 msgid "niri-flake"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:724
+#: configuration.org:742
 msgid "https://github.com/sodiboo/niri-flake"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:727
+#: configuration.org:745
 msgid "Nix-native configuration for niri"
 msgstr "NixによるNiriの設定"
 
 #. type: paragraph
-#: configuration.org:730
+#: configuration.org:748
 msgid ""
 "Niri is a scrollable-tiling Wayland compositor. This flake provides the "
 "compositor and related modules for NixOS/home-manager integration."
@@ -1667,7 +1714,7 @@ msgstr ""
 "ターとNixOS/home-manager統合のための関連モジュールを提供します。"
 
 #. type: paragraph in src
-#: configuration.org:735
+#: configuration.org:753
 #, no-wrap
 msgid ""
 "niri-flake = {\n"
@@ -1682,7 +1729,7 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:746 configuration.org:752
+#: configuration.org:764 configuration.org:770
 #: modules/features/emacs/init.org:792
 #, fuzzy, no-wrap
 #| msgid "org-agenda"
@@ -1690,17 +1737,17 @@ msgid "org-clickup"
 msgstr "org-agenda"
 
 #. type: paragraph
-#: configuration.org:748
+#: configuration.org:766
 msgid "https://git.natsukium.com/natsukium/org-clickup"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:750
+#: configuration.org:768
 msgid "Emacs package for bidirectional ClickUp ↔ org-mode sync."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:754
+#: configuration.org:772
 #, no-wrap
 msgid ""
 "org-clickup = {\n"
@@ -1710,18 +1757,18 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:760 configuration.org:767
+#: configuration.org:778 configuration.org:785
 #, no-wrap
 msgid "nur-packages"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:762
+#: configuration.org:780
 msgid "https://github.com/natsukium/nur-packages"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:764
+#: configuration.org:782
 msgid ""
 "Personal NUR (Nix User Repository). Contains packages maintained personally "
 "that are either too niche for nixpkgs or require customizations."
@@ -1730,7 +1777,7 @@ msgstr ""
 "ズが必要な個人的にメンテナンスしているパッケージを含みます。"
 
 #. type: paragraph in src
-#: configuration.org:769
+#: configuration.org:787
 #, no-wrap
 msgid ""
 "nur-packages = {\n"
@@ -1740,25 +1787,25 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:775 configuration.org:793
+#: configuration.org:793 configuration.org:811
 #, no-wrap
 msgid "paneru"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:777
+#: configuration.org:795
 msgid ""
 "https://github.com/karinushka/paneru (fork: https://github.com/natsukium/"
 "paneru)"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:780
+#: configuration.org:798
 msgid "A sliding, tiling window manager for MacOS."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:783
+#: configuration.org:801
 msgid ""
 "Paneru brings the Niri-style scrollable tiling workflow used on Linux "
 "machines to macOS. Among the window managers tried for this purpose, it has "
@@ -1766,7 +1813,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:787
+#: configuration.org:805
 msgid ""
 "The =natsukium/paneru= fork exists for a single reason: upstream tiles Emacs "
 "child frames — the floating windows used by completion UIs such as Corfu — "
@@ -1777,7 +1824,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:795
+#: configuration.org:813
 #, no-wrap
 msgid ""
 "paneru = {\n"
@@ -1789,23 +1836,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:803 configuration.org:814
+#: configuration.org:821 configuration.org:832
 #, no-wrap
 msgid "simple-wol-manager"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:805
+#: configuration.org:823
 msgid "https://git.natsukium.com/natsukium/simple-wol-manager"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:808
+#: configuration.org:826
 msgid "A web-based application for managing Wake-on-LAN (WoL) devices"
 msgstr "Wake-on-LAN (WoL) デバイスを管理するWebアプリケーション"
 
 #. type: paragraph
-#: configuration.org:811
+#: configuration.org:829
 msgid ""
 "Personal Wake-on-LAN management tool. Provides a web interface for sending "
 "WoL packets and managing device configurations."
@@ -1814,7 +1861,7 @@ msgstr ""
 "Webインターフェースを提供します。"
 
 #. type: paragraph in src
-#: configuration.org:816
+#: configuration.org:834
 #, no-wrap
 msgid ""
 "simple-wol-manager = {\n"
@@ -1824,23 +1871,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:822 configuration.org:835
+#: configuration.org:840 configuration.org:853
 #, no-wrap
 msgid "spoor"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:824
+#: configuration.org:842
 msgid "https://git.natsukium.com/natsukium/spoor"
 msgstr ""
 
 #. type: paragraph in quote
-#: configuration.org:827
+#: configuration.org:845
 msgid "A standalone, terminal-agnostic hint picker for scrollback."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:830
+#: configuration.org:848
 msgid ""
 "My own take on tmux-thumbs' standalone mode: pipe text in, it labels the "
 "matches, and on selection it copies, opens, or runs a command with the "
@@ -1849,7 +1896,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:837
+#: configuration.org:855
 #, no-wrap
 msgid ""
 "spoor = {\n"
@@ -1860,28 +1907,28 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:844 configuration.org:854
+#: configuration.org:862 configuration.org:872
 #, no-wrap
 msgid "vicinae"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:846
+#: configuration.org:864
 msgid "https://github.com/vicinaehq/vicinae"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:849
+#: configuration.org:867
 msgid "A focused, keyboard-driven launcher for getting things done."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:852
+#: configuration.org:870
 msgid "Vicinae is a Raycast-style native launcher."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:856
+#: configuration.org:874
 #, no-wrap
 msgid ""
 "vicinae = {\n"
@@ -1891,23 +1938,23 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:862 configuration.org:873
+#: configuration.org:880 configuration.org:891
 #, no-wrap
 msgid "zen-browser"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:864
+#: configuration.org:882
 msgid "https://github.com/0xc000022070/zen-browser-flake"
 msgstr ""
 
 #. type: paragraph in QUOTE
-#: configuration.org:867
+#: configuration.org:885
 msgid "Community-driven Nix Flake for the Zen browser"
 msgstr "Zen Browser向けコミュニティ主導のNix Flake"
 
 #. type: paragraph
-#: configuration.org:870
+#: configuration.org:888
 msgid ""
 "Firefox-based browser focused on privacy. Community flake providing Nix "
 "packaging with home-manager integration."
@@ -1916,7 +1963,7 @@ msgstr ""
 "Nixパッケージングを提供するコミュニティflakeです。"
 
 #. type: paragraph in src
-#: configuration.org:875
+#: configuration.org:893
 #, no-wrap
 msgid ""
 "zen-browser = {\n"
@@ -1927,13 +1974,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:883
+#: configuration.org:901
 #, no-wrap
 msgid "Nix Config"
 msgstr "Nixの設定"
 
 #. type: paragraph
-#: configuration.org:885
+#: configuration.org:903
 msgid ""
 "Nix settings used by this flake. While these settings are already configured "
 "on all managed machines, documenting them here helps with initial setup and "
@@ -1944,7 +1991,7 @@ msgstr ""
 "のflakeを利用する際にも役立ちます。"
 
 #. type: paragraph
-#: configuration.org:888
+#: configuration.org:906
 msgid ""
 "For detailed documentation on each setting, see https://nix.dev/manual/nix/"
 "latest/command-ref/conf-file.html"
@@ -1953,7 +2000,7 @@ msgstr ""
 "conf-file.html を参照してください。"
 
 #. type: paragraph
-#: configuration.org:891
+#: configuration.org:909
 msgid ""
 "Note: =flake.nix= uses a restricted subset of the Nix language that prevents "
 "code reuse (see https://github.com/NixOS/nix/issues/4945). The values below "
@@ -1968,13 +2015,13 @@ msgstr ""
 "ようになります。"
 
 #. type: heading ****
-#: configuration.org:896 modules/configuration.org:172
+#: configuration.org:914 modules/configuration.org:172
 #, no-wrap
 msgid "Binary Caches"
 msgstr "バイナリキャッシュ"
 
 #. type: paragraph
-#: configuration.org:898
+#: configuration.org:916
 msgid ""
 "Binary cache (substituter) configuration for building this flake. While "
 "optional, configuring these caches significantly reduces build times by "
@@ -1985,7 +2032,7 @@ msgstr ""
 "にビルド済みバイナリをダウンロードするため、ビルド時間を大幅に短縮できます。"
 
 #. type: paragraph
-#: configuration.org:902
+#: configuration.org:920
 msgid ""
 "Using =extra-substituters= and =extra-trusted-public-keys= instead of "
 "=substituters= and =trusted-public-keys= ensures this flake's cache "
@@ -1999,13 +2046,13 @@ msgstr ""
 "ザーが =nix.conf= やシステム設定で既に設定しているキャッシュが尊重されます。"
 
 #. type: keyword NAME
-#: configuration.org:907 modules/configuration.org:82
+#: configuration.org:925 modules/configuration.org:82
 #, no-wrap
 msgid "nix-config"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:909
+#: configuration.org:927
 #, no-wrap
 msgid ""
 "extra-substituters = [\n"
@@ -2016,7 +2063,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:915
+#: configuration.org:933
 #, no-wrap
 msgid ""
 "extra-trusted-public-keys = [\n"
@@ -2027,13 +2074,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *****
-#: configuration.org:922
+#: configuration.org:940
 #, no-wrap
 msgid "cache.nixos-cuda.org"
 msgstr "cache.nixos-cuda.org"
 
 #. type: paragraph
-#: configuration.org:924
+#: configuration.org:942
 msgid ""
 "Binary cache for CUDA-related packages. These were distributed under the nix-"
 "community namespace before, and since November 2025 come from the CUDA "
@@ -2041,11 +2088,11 @@ msgid ""
 "hydra.nixos-cuda.org/project/nixos-cuda"
 msgstr ""
 "CUDA関連パッケージのバイナリキャッシュです。以前はnix-community名前空間で配布"
-"されていましたが、2025年11月以降はCUDAチーム自身の基盤から配布されています。ビ"
-"ルド状況は https://hydra.nixos-cuda.org/project/nixos-cuda で確認できます。"
+"されていましたが、2025年11月以降はCUDAチーム自身の基盤から配布されています。"
+"ビルド状況は https://hydra.nixos-cuda.org/project/nixos-cuda で確認できます。"
 
 #. type: paragraph
-#: configuration.org:928
+#: configuration.org:946
 msgid ""
 "The nixos-cuda team describes this cache as being for development purposes "
 "only.  Alternatively, Flox's binary cache can be used for CUDA packages. As "
@@ -2055,34 +2102,34 @@ msgid ""
 msgstr ""
 "nixos-cudaチームはこのキャッシュを開発用途のみのものとしています。代替とし"
 "て、CUDAパッケージにFloxのバイナリキャッシュも利用できます。2025年9月時点で、"
-"FloxはNVIDIAと提携して再配布権を取得しています。https://discourse.nixos.org/t/"
-"nix-flox-nvidia-opening-up-cuda-redistribution-on-nix/69189 を参照してくださ"
-"い。"
+"FloxはNVIDIAと提携して再配布権を取得しています。https://discourse.nixos.org/"
+"t/nix-flox-nvidia-opening-up-cuda-redistribution-on-nix/69189 を参照してくだ"
+"さい。"
 
 #. type: heading *****
-#: configuration.org:933
+#: configuration.org:951
 #, no-wrap
 msgid "natsukium.cachix.org"
 msgstr "natsukium.cachix.org"
 
 #. type: paragraph
-#: configuration.org:935
+#: configuration.org:953
 msgid ""
 "Personal binary cache containing outputs from this flake. Packages not "
 "available in the official =cache.nixos.org= are built on GitHub Actions and "
 "pushed here."
 msgstr ""
-"このflakeの出力を含む個人バイナリキャッシュです。公式の =cache.nixos.org= にな"
-"いパッケージはGitHub Actionsでビルドされ、ここにプッシュされます。"
+"このflakeの出力を含む個人バイナリキャッシュです。公式の =cache.nixos.org= に"
+"ないパッケージはGitHub Actionsでビルドされ、ここにプッシュされます。"
 
 #. type: heading ***
-#: configuration.org:938
+#: configuration.org:956
 #, no-wrap
 msgid "Hosts"
 msgstr "ホスト"
 
 #. type: paragraph
-#: configuration.org:940
+#: configuration.org:958
 msgid ""
 "An overview of the managed machines. Each host's full configuration lives in "
 "its own =hosts/<platform>/<name>/= directory, picked up by the loader in "
@@ -2090,27 +2137,27 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:946
+#: configuration.org:964
 msgid "Main laptop (M1 MacBook Air)."
 msgstr "メインラップトップ（M1 MacBook Air）。"
 
 #. type: paragraph
-#: configuration.org:950
+#: configuration.org:968
 msgid "Build server (M1 Mac mini)."
 msgstr "ビルドサーバー（M1 Mac mini）。"
 
 #. type: paragraph
-#: configuration.org:954
+#: configuration.org:972
 msgid "Laptop for work (M4 MacBook Pro)."
 msgstr "仕事用ラップトップ（M4 MacBook Pro）。"
 
 #. type: paragraph
-#: configuration.org:958
+#: configuration.org:976
 msgid "Main desktop (Intel Core i5-12400F)."
 msgstr "メインデスクトップ（Intel Core i5-12400F）。"
 
 #. type: paragraph
-#: configuration.org:960 configuration.org:1030
+#: configuration.org:978 configuration.org:1048
 msgid ""
 "Wake-on-LAN (WoL) is enabled via the following BIOS setting: =Advanced > APM "
 "Configuration > Power On By PCI-E > Enabled="
@@ -2119,18 +2166,18 @@ msgstr ""
 "Configuration > Power On By PCI-E > Enabled="
 
 #. type: paragraph
-#: configuration.org:965
+#: configuration.org:983
 msgid "WSL (dual boot with kilimanjaro)."
 msgstr "WSL（kilimanjaroとデュアルブート）。"
 
 #. type: heading *****
-#: configuration.org:967
+#: configuration.org:985
 #, no-wrap
 msgid "Setup"
 msgstr "セットアップ"
 
 #. type: paragraph
-#: configuration.org:969
+#: configuration.org:987
 msgid ""
 "Setting up arusha requires both Windows-side and WSL-side steps. The process "
 "follows [[https://github.com/nix-community/NixOS-WSL][NixOS-WSL]]'s quick "
@@ -2141,13 +2188,13 @@ msgstr ""
 "イドに従います。"
 
 #. type: heading ******
-#: configuration.org:972
+#: configuration.org:990
 #, no-wrap
 msgid "Installing WSL"
 msgstr "WSLのインストール"
 
 #. type: paragraph
-#: configuration.org:974
+#: configuration.org:992
 msgid ""
 "=--no-distribution= avoids installing the default Ubuntu distribution, which "
 "would just be removed after importing NixOS."
@@ -2157,60 +2204,60 @@ msgstr ""
 "す。"
 
 #. type: paragraph in src
-#: configuration.org:978
+#: configuration.org:996
 #, no-wrap
 msgid "wsl --install --no-distribution"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:981
+#: configuration.org:999
 #, no-wrap
 msgid "Importing NixOS-WSL"
 msgstr "NixOS-WSLのインポート"
 
 #. type: paragraph
-#: configuration.org:983
+#: configuration.org:1001
 msgid "Download the latest NixOS-WSL release image and import it."
 msgstr "最新のNixOS-WSLリリースイメージをダウンロードしてインポートします。"
 
 #. type: cell column 0
-#: configuration.org:987
+#: configuration.org:1005
 #, no-wrap
 msgid "Select-Object -ExpandProperty assets `"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:988
+#: configuration.org:1006
 #, no-wrap
 msgid "Where-Object { $_.name -eq \"nixos.wsl\" } `"
 msgstr ""
 
 #. type: cell column 0
-#: configuration.org:989
+#: configuration.org:1007
 #, no-wrap
 msgid "ForEach-Object { Invoke-WebRequest -Uri $_.browser_download_url -OutFile $_.name }"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:986
+#: configuration.org:1004
 #, no-wrap
 msgid "Invoke-RestMethod -Uri https://api.github.com/repos/nix-community/nixos-wsl/releases/latest `"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:993
+#: configuration.org:1011
 #, no-wrap
 msgid "./nixos.wsl"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:996
+#: configuration.org:1014
 #, no-wrap
 msgid "Applying the configuration"
 msgstr "設定の適用"
 
 #. type: paragraph
-#: configuration.org:998
+#: configuration.org:1016
 msgid ""
 "After the initial NixOS-WSL boot, apply this flake's configuration directly "
 "from GitHub. No local clone is needed for the first run."
@@ -2219,25 +2266,25 @@ msgstr ""
 "にローカルへのクローンは不要です。"
 
 #. type: paragraph in src
-#: configuration.org:1002
+#: configuration.org:1020
 #, no-wrap
 msgid "wsl -d NixOS"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1006
+#: configuration.org:1024
 #, no-wrap
 msgid "sudo nixos-rebuild switch --flake github:natsukium/dotfiles#arusha"
 msgstr ""
 
 #. type: heading ******
-#: configuration.org:1009
+#: configuration.org:1027
 #, no-wrap
 msgid "Windows-side CLI tools"
 msgstr "Windows側のCLIツール"
 
 #. type: paragraph
-#: configuration.org:1011
+#: configuration.org:1029
 msgid ""
 "Windows 24H2 includes a built-in =sudo= command, so =winget= can be elevated "
 "inline without a separate UAC prompt."
@@ -2246,7 +2293,7 @@ msgstr ""
 "示せずに =winget= をインラインで昇格できます。"
 
 #. type: paragraph
-#: configuration.org:1016
+#: configuration.org:1034
 msgid ""
 "A mini PC with Intel N100, serving as a lightweight home server.  https://"
 "www.bee-link.com/products/beelink-mini-s12-pro-n100"
@@ -2255,7 +2302,7 @@ msgstr ""
 "www.bee-link.com/products/beelink-mini-s12-pro-n100"
 
 #. type: paragraph
-#: configuration.org:1019
+#: configuration.org:1037
 msgid ""
 "BIOS is configured with the following setting to automatically power on "
 "after an outage: =Chipset > PCH-IO Configuration > State After G3 > S0 State="
@@ -2264,28 +2311,28 @@ msgstr ""
 "IO Configuration > State After G3 > S0 State="
 
 #. type: paragraph
-#: configuration.org:1024
+#: configuration.org:1042
 msgid "Build server (OCI A1 Flex)."
 msgstr "ビルドサーバー（OCI A1 Flex）。"
 
 #. type: paragraph
-#: configuration.org:1028
+#: configuration.org:1046
 msgid "Build server (Ryzen 9 9950X)."
 msgstr "ビルドサーバー（Ryzen 9 9950X）。"
 
 #. type: paragraph
-#: configuration.org:1035
+#: configuration.org:1053
 msgid "Phone (Pixel 7a)."
 msgstr "スマートフォン（Pixel 7a）。"
 
 #. type: heading ***
-#: configuration.org:1037
+#: configuration.org:1055
 #, no-wrap
 msgid "Outputs"
 msgstr "出力"
 
 #. type: paragraph
-#: configuration.org:1039
+#: configuration.org:1057
 msgid ""
 "Each per-system concern lives in its own =modules/per-system/*.nix= file, "
 "documented in =[[Per-system modules]]= below. The outputs body wires them "
@@ -2294,13 +2341,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: configuration.org:1043
+#: configuration.org:1061
 #, no-wrap
 msgid "outputs"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1045
+#: configuration.org:1063
 #, no-wrap
 msgid ""
 "systems = [\n"
@@ -2311,7 +2358,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1051
+#: configuration.org:1069
 #, no-wrap
 msgid ""
 "imports = [\n"
@@ -2320,7 +2367,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1055
+#: configuration.org:1073
 #, no-wrap
 msgid ""
 "flake = {\n"
@@ -2329,14 +2376,14 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1060
+#: configuration.org:1078
 #, fuzzy, no-wrap
 #| msgid "NixOS-specific system modules."
 msgid "Per-system modules"
 msgstr "NixOS固有のシステムモジュールです。"
 
 #. type: paragraph
-#: configuration.org:1062
+#: configuration.org:1080
 msgid ""
 "Per-concern flake-parts modules that each contribute to =perSystem=. "
 "Splitting them keeps =flake.nix= small and lets each concern carry its own "
@@ -2345,12 +2392,12 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1067
+#: configuration.org:1085
 msgid "The shared pattern is:"
 msgstr ""
 
 #. type: paragraph in SRC
-#: configuration.org:1070
+#: configuration.org:1088
 #, no-wrap
 msgid ""
 "{ ... }: # or { self, inputs, ... }: when the module needs them\n"
@@ -2364,21 +2411,21 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1080
+#: configuration.org:1098
 #, fuzzy, no-wrap
 #| msgid "Nixpkgs"
 msgid "Nixpkgs instance"
 msgstr "Nixpkgs"
 
 #. type: paragraph
-#: configuration.org:1082
+#: configuration.org:1100
 msgid ""
 "Constructs the per-system =pkgs= with overlays applied, exposed to all other "
 "=perSystem= consumers via =_module.args.pkgs=."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1085
+#: configuration.org:1103
 msgid ""
 "=allowUnfree= is enabled because several desktop hosts pull in unfree "
 "packages (NVIDIA drivers on =kilimanjaro=, =1password=, etc.) and gating "
@@ -2386,7 +2433,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1090
+#: configuration.org:1108
 #, no-wrap
 msgid ""
 "{ self, inputs, ... }:\n"
@@ -2404,13 +2451,13 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1104
+#: configuration.org:1122
 #, no-wrap
 msgid "Checks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1106
+#: configuration.org:1124
 msgid ""
 "Re-exports the NixOS VM tests under =./tests= as flake checks for the "
 "current system. Kept in its own module so the test wiring is easy to find "
@@ -2418,7 +2465,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1111
+#: configuration.org:1129
 #, no-wrap
 msgid ""
 "{ inputs, self, ... }:\n"
@@ -2435,19 +2482,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1124
+#: configuration.org:1142
 #, fuzzy, no-wrap
 #| msgid "Nix Packages"
 msgid "Packages"
 msgstr "Nixパッケージ"
 
 #. type: paragraph
-#: configuration.org:1126
+#: configuration.org:1144
 msgid "Per-system packages exposed as flake outputs."
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1128
+#: configuration.org:1146
 msgid ""
 "The =html= package builds the published documentation ([[*Documentation]"
 "[Documentation]]). The build itself lives in [[file:scripts/build-html.sh]"
@@ -2459,7 +2506,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1135
+#: configuration.org:1153
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -2496,7 +2543,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1167
+#: configuration.org:1185
 #, no-wrap
 msgid ""
 "            installPhase = ''\n"
@@ -2512,37 +2559,37 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1179
+#: configuration.org:1197
 #, no-wrap
 msgid "Overlays"
 msgstr "Overlay"
 
 #. type: keyword INCLUDE
-#: configuration.org:1180
+#: configuration.org:1198
 #, no-wrap
 msgid "\"./overlays/configuration.org\""
 msgstr "\"./overlays/configuration.ja.org\""
 
 #. type: heading **
-#: configuration.org:1182
+#: configuration.org:1200
 #, no-wrap
 msgid "Modules"
 msgstr "モジュール"
 
 #. type: keyword INCLUDE
-#: configuration.org:1183
+#: configuration.org:1201
 #, no-wrap
 msgid "\"./modules/configuration.org\""
 msgstr "\"./modules/configuration.ja.org\""
 
 #. type: heading **
-#: configuration.org:1185
+#: configuration.org:1203
 #, no-wrap
 msgid "Scripts"
 msgstr "スクリプト"
 
 #. type: paragraph
-#: configuration.org:1187
+#: configuration.org:1205
 msgid ""
 "Scripts used in flake derivations, pre-commit hooks, and Makefile recipes.  "
 "Extracted to separate files for proper syntax highlighting and independent "
@@ -2553,7 +2600,7 @@ msgstr ""
 "しています。"
 
 #. type: paragraph
-#: configuration.org:1190
+#: configuration.org:1208
 msgid ""
 "=org-to-html.el= drives the documentation export. Four choices shape it. "
 "First, htmlize emits =org-*= class names rather than inline colors, so the "
@@ -2567,7 +2614,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1198
+#: configuration.org:1216
 msgid ""
 "Third, every code block that tangles is headed by a link to the file it "
 "produces.  Literate configuration only pays off if a reader can get from the "
@@ -2581,7 +2628,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1208
+#: configuration.org:1226
 msgid ""
 "Fourth, noweb references link to the block that defines them, and a "
 "referenced block is headed by its own name. A tangled file is assembled from "
@@ -2593,7 +2640,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1217
+#: configuration.org:1235
 #, no-wrap
 msgid ""
 "(require 'cl-lib)\n"
@@ -2604,7 +2651,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1223
+#: configuration.org:1241
 #, no-wrap
 msgid ""
 "(add-to-list 'org-src-lang-modes '(\"nix\" . nix-ts))\n"
@@ -2612,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1226
+#: configuration.org:1244
 #, no-wrap
 msgid ""
 ";; Emit `org-*' class names on syntax spans instead of inline color styles, so\n"
@@ -2622,7 +2669,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1231
+#: configuration.org:1249
 #, no-wrap
 msgid ""
 ";; Export five headline levels as real headings (default is 3). Deeper sections\n"
@@ -2632,7 +2679,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1236
+#: configuration.org:1254
 #, no-wrap
 msgid ""
 ";; The frame styling is my own; drop Org's default <style> and scripts.\n"
@@ -2641,7 +2688,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1240
+#: configuration.org:1258
 #, no-wrap
 msgid ""
 ";; Don't abort the whole documentation build over one dangling link. The\n"
@@ -2653,7 +2700,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1247
+#: configuration.org:1265
 #, no-wrap
 msgid ""
 ";; Inline the stylesheet and script rather than <link>/<script src>-ing them, so\n"
@@ -2668,7 +2715,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1257
+#: configuration.org:1275
 #, no-wrap
 msgid ""
 "(setq org-html-head\n"
@@ -2677,7 +2724,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1261
+#: configuration.org:1279
 #, no-wrap
 msgid ""
 ";; Fold the table of contents: rewrite Org's #table-of-contents <div> into a\n"
@@ -2699,13 +2746,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1278
+#: configuration.org:1296
 #, no-wrap
 msgid "(add-to-list 'org-export-filter-final-output-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1281
+#: configuration.org:1299
 #, no-wrap
 msgid ""
 ";; Head every code block with the file it tangles to, linked to GitHub.\n"
@@ -2723,7 +2770,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1294
+#: configuration.org:1312
 #, no-wrap
 msgid ""
 ";; Documents that declare `:tangle' targets, and the prefix their paths are\n"
@@ -2738,13 +2785,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1304
+#: configuration.org:1322
 #, no-wrap
 msgid "(defvar dotfiles-tangle-map nil)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1306
+#: configuration.org:1324
 #, no-wrap
 msgid ""
 "(defun dotfiles-src-block-target (src-block prefix)\n"
@@ -2765,7 +2812,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1322
+#: configuration.org:1340
 #, no-wrap
 msgid ""
 "(defun dotfiles-build-tangle-map (suffix)\n"
@@ -2792,7 +2839,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1344
+#: configuration.org:1362
 #, no-wrap
 msgid ""
 ";; Turn noweb references into links to the block that defines them, so the\n"
@@ -2802,7 +2849,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1349
+#: configuration.org:1367
 #, no-wrap
 msgid ""
 "(defun dotfiles-collect-noweb-names (tree _backend _info)\n"
@@ -2824,13 +2871,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1366 configuration.org:1544
+#: configuration.org:1384 configuration.org:1562
 #, no-wrap
 msgid "(add-to-list 'org-export-filter-parse-tree-functions"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1369
+#: configuration.org:1387
 #, no-wrap
 msgid ""
 "(defconst dotfiles-noweb-token \"nowebref0%s0\"\n"
@@ -2838,7 +2885,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1372
+#: configuration.org:1390
 #, no-wrap
 msgid ""
 "(defun dotfiles-noweb-anchor (name)\n"
@@ -2850,7 +2897,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1379
+#: configuration.org:1397
 #, no-wrap
 msgid ""
 "(defun dotfiles-noweb-html (name)\n"
@@ -2862,7 +2909,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1386
+#: configuration.org:1404
 #, no-wrap
 msgid ""
 "(defun dotfiles-fontify-noweb (original code lang &rest args)\n"
@@ -2891,13 +2938,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1410
+#: configuration.org:1428
 #, no-wrap
 msgid "(advice-add 'org-html-fontify-code :around #'dotfiles-fontify-noweb)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1412
+#: configuration.org:1430
 #, no-wrap
 msgid ""
 "(defconst dotfiles-src-lang-names '((\"emacs-lisp\" . \"elisp\"))\n"
@@ -2905,13 +2952,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1415
+#: configuration.org:1433
 #, no-wrap
 msgid "(defconst dotfiles-src-container \"<div class=\\\"org-src-container\\\">\\n\")"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1417
+#: configuration.org:1435
 #, no-wrap
 msgid ""
 "(defun dotfiles-html-src-block-head (original src-block contents info)\n"
@@ -2947,13 +2994,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1448
+#: configuration.org:1466
 #, no-wrap
 msgid "(advice-add 'org-html-src-block :around #'dotfiles-html-src-block-head)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1450
+#: configuration.org:1468
 #, no-wrap
 msgid ""
 ";; Anchor headings by a slug of their title instead of the generated org<hash>.\n"
@@ -2967,7 +3014,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1459
+#: configuration.org:1477
 #, no-wrap
 msgid ""
 "(defun dotfiles-slugify (text)\n"
@@ -2980,7 +3027,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1467
+#: configuration.org:1485
 #, no-wrap
 msgid ""
 "(defun dotfiles-title-slug (headline)\n"
@@ -2993,7 +3040,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1475
+#: configuration.org:1493
 #, no-wrap
 msgid ""
 "(defun dotfiles-heading-slug (headline)\n"
@@ -3021,7 +3068,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1498
+#: configuration.org:1516
 #, no-wrap
 msgid ""
 ";; Slugs are assigned here, in one pass over the finished tree, rather than when\n"
@@ -3035,7 +3082,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1507
+#: configuration.org:1525
 #, no-wrap
 msgid ""
 "(defvar dotfiles-translating nil\n"
@@ -3043,7 +3090,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1510
+#: configuration.org:1528
 #, no-wrap
 msgid ""
 "(defun dotfiles-assign-heading-slugs (tree _backend _info)\n"
@@ -3082,7 +3129,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1547
+#: configuration.org:1565
 #, no-wrap
 msgid ""
 "(defun dotfiles-export-get-reference (original datum info)\n"
@@ -3093,13 +3140,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1553
+#: configuration.org:1571
 #, no-wrap
 msgid "(advice-add 'org-export-get-reference :around #'dotfiles-export-get-reference)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1555
+#: configuration.org:1573
 #, no-wrap
 msgid ""
 ";; A heading is only linkable if the reader can get at its URL, so each one ends\n"
@@ -3124,13 +3171,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1575
+#: configuration.org:1593
 #, no-wrap
 msgid "(advice-add 'org-html-headline :around #'dotfiles-html-headline-anchor)"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1577
+#: configuration.org:1595
 #, no-wrap
 msgid ""
 "(defun dotfiles-export-html (lang)\n"
@@ -3147,7 +3194,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1589
+#: configuration.org:1607
 #, no-wrap
 msgid ""
 ";; Which editions to export, set by scripts/build-html.sh. Building English\n"
@@ -3158,7 +3205,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1596
+#: configuration.org:1614
 msgid ""
 "=build-html.sh= wraps that export so the same command produces the published "
 "site and a local preview. The build used to live in the Nix derivation, "
@@ -3169,7 +3216,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1603
+#: configuration.org:1621
 msgid ""
 "Emacs writes each page beside its source document, so the script moves the "
 "results into an output directory and deletes what Emacs left behind; kept "
@@ -3177,14 +3224,14 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1608 configuration.org:1666 configuration.org:1685
-#: configuration.org:1692
+#: configuration.org:1626 configuration.org:1684 configuration.org:1703
+#: configuration.org:1710
 #, no-wrap
 msgid "set -euo pipefail"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1610
+#: configuration.org:1628
 #, no-wrap
 msgid ""
 "output=build\n"
@@ -3192,7 +3239,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1613
+#: configuration.org:1631
 #, no-wrap
 msgid ""
 "while [ $# -gt 0 ]; do\n"
@@ -3214,13 +3261,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1630
+#: configuration.org:1648
 #, no-wrap
 msgid "cd \"$(dirname \"$0\")/..\""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1634
+#: configuration.org:1652
 #, no-wrap
 msgid ""
 "translations=$(tr ' ' '\\n' <<<\"$langs\" | grep -vx -e en -e '' | tr '\\n' ' ' || true)\n"
@@ -3228,7 +3275,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1641
+#: configuration.org:1659
 #, no-wrap
 msgid ""
 "if [ -n \"$translations\" ]; then\n"
@@ -3237,13 +3284,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1645
+#: configuration.org:1663
 #, no-wrap
 msgid "DOTFILES_HTML_LANGS=\"$langs\" emacs --batch -l scripts/org-to-html.el"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1647
+#: configuration.org:1665
 #, no-wrap
 msgid ""
 "for lang in $langs; do\n"
@@ -3261,7 +3308,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1668
+#: configuration.org:1686
 #, no-wrap
 msgid ""
 "message=\"$1\"\n"
@@ -3269,13 +3316,13 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1671
+#: configuration.org:1689
 #, no-wrap
 msgid "changed=$(git diff --name-only \"$@\")"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1673
+#: configuration.org:1691
 #, no-wrap
 msgid ""
 "if [ -n \"$changed\" ]; then\n"
@@ -3290,7 +3337,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1687
+#: configuration.org:1705
 #, no-wrap
 msgid ""
 "po4a po4a.cfg\n"
@@ -3298,7 +3345,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1694
+#: configuration.org:1712
 #, no-wrap
 msgid ""
 "make -B tangle -j\n"
@@ -3306,7 +3353,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1699
+#: configuration.org:1717
 #, no-wrap
 msgid ""
 "(require 'ox-md)\n"
@@ -3315,7 +3362,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1704
+#: configuration.org:1722
 msgid ""
 "The =org-export-with-author= setting is explicitly disabled because "
 "=configuration.org= has no =#+AUTHOR:= keyword, so Org falls back to the "
@@ -3333,7 +3380,7 @@ msgstr ""
 "効にすることで、プラットフォーム間で一貫した出力を保証します。"
 
 #. type: paragraph in src
-#: configuration.org:1713
+#: configuration.org:1731
 #, no-wrap
 msgid ""
 "(require 'ox-org)\n"
@@ -3345,13 +3392,13 @@ msgid ""
 msgstr ""
 
 #. type: heading *
-#: configuration.org:1721 .github/README.org:56
+#: configuration.org:1739 .github/README.org:56
 #, no-wrap
 msgid "Development"
 msgstr "開発"
 
 #. type: paragraph
-#: configuration.org:1723 .github/README.org:58
+#: configuration.org:1741 .github/README.org:58
 msgid ""
 "This repository provides a Nix development shell with all the tools needed "
 "for working on the configurations. Enter the shell by running:"
@@ -3360,13 +3407,13 @@ msgstr ""
 "す。以下のコマンドでシェルに入れます："
 
 #. type: paragraph in src
-#: configuration.org:1727 .github/README.org:62
+#: configuration.org:1745 .github/README.org:62
 #, no-wrap
 msgid "nix develop"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1730 .github/README.org:65
+#: configuration.org:1748 .github/README.org:65
 msgid ""
 "The shell includes infrastructure tools (Terraform, sops, ssh-to-age), "
 "translation tools (po4a, gettext), and build utilities (nix-fast-build).  On "
@@ -3379,7 +3426,7 @@ msgstr ""
 "的ソースからの =CLAUDE.md= 同期が行われます。"
 
 #. type: paragraph in src
-#: configuration.org:1736 .github/README.org:71
+#: configuration.org:1754 .github/README.org:71
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -3424,7 +3471,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1776 .github/README.org:111
+#: configuration.org:1794 .github/README.org:111
 #, no-wrap
 msgid ""
 "        terraform = pkgs.mkShell {\n"
@@ -3436,13 +3483,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1784 .github/README.org:118
+#: configuration.org:1802 .github/README.org:118
 #, no-wrap
 msgid "Pre-commit hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1786 .github/README.org:120
+#: configuration.org:1804 .github/README.org:120
 msgid ""
 "Hooks run by [[https://github.com/cachix/git-hooks.nix][git-hooks.nix]] on "
 "every commit. =prek= is used as the runner because it is the actively-"
@@ -3451,7 +3498,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1790 .github/README.org:124
+#: configuration.org:1808 .github/README.org:124
 msgid ""
 "=check-org-tangle= is the only hook with =priority = 0= because it must run "
 "before everything else: if Org files are out of sync, formatters and linters "
@@ -3460,7 +3507,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1796 .github/README.org:130
+#: configuration.org:1814 .github/README.org:130
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3469,7 +3516,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1800 .github/README.org:134
+#: configuration.org:1818 .github/README.org:134
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -3582,14 +3629,14 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1910 .github/README.org:243
+#: configuration.org:1928 .github/README.org:243
 #, fuzzy, no-wrap
 #| msgid "Core Settings"
 msgid "Formatting"
 msgstr "コア設定"
 
 #. type: paragraph
-#: configuration.org:1912 .github/README.org:245
+#: configuration.org:1930 .github/README.org:245
 msgid ""
 "Formatters are aggregated via [[https://github.com/numtide/treefmt-nix]"
 "[treefmt-nix]] and invoked from the =treefmt= pre-commit hook, so a single "
@@ -3597,7 +3644,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1917 .github/README.org:250
+#: configuration.org:1935 .github/README.org:250
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3606,7 +3653,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1921 .github/README.org:254
+#: configuration.org:1939 .github/README.org:254
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3627,13 +3674,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1938 .github/README.org:270
+#: configuration.org:1956 .github/README.org:270
 #, no-wrap
 msgid "MCP Servers"
 msgstr "MCPサーバー"
 
 #. type: paragraph
-#: configuration.org:1940 .github/README.org:272
+#: configuration.org:1958 .github/README.org:272
 msgid ""
 "Configuration for [[https://github.com/natsukium/mcp-servers-nix][mcp-"
 "servers-nix]], enabled in the development shell.  The =flavors.claude-code= "
@@ -3645,30 +3692,30 @@ msgstr ""
 "の期待するフォーマットと互換性のある =.mcp.json= ファイルが生成されます。"
 
 #. type: plain list -
-#: configuration.org:1946 .github/README.org:278
+#: configuration.org:1964 .github/README.org:278
 #, no-wrap
 msgid "=nixos=: NixOS package/option search and Home Manager documentation"
 msgstr "=nixos=: NixOSパッケージ/オプション検索とHome Managerのドキュメント"
 
 #. type: plain list -
-#: configuration.org:1947 .github/README.org:279
+#: configuration.org:1965 .github/README.org:279
 #, no-wrap
 msgid "=terraform=: Terraform registry lookup for providers, modules, and policies"
 msgstr "=terraform=: Terraformレジストリのプロバイダー、モジュール、ポリシー検索"
 
 #. type: plain list -
-#: configuration.org:1948 .github/README.org:280
+#: configuration.org:1966 .github/README.org:280
 #, no-wrap
 msgid "=grafana=: Query dashboards, datasources, and metrics from the home server's Grafana instance"
 msgstr "=grafana=: ホームサーバーのGrafanaインスタンスからダッシュボード、データソース、メトリクスを照会"
 
 #. type: paragraph
-#: configuration.org:1944 .github/README.org:276
+#: configuration.org:1962 .github/README.org:276
 msgid "Enabled servers:"
 msgstr "有効なサーバー："
 
 #. type: paragraph
-#: configuration.org:1949 .github/README.org:281
+#: configuration.org:1967 .github/README.org:281
 msgid ""
 "The =passwordCommand= option retrieves secrets at runtime using =rbw= "
 "(Bitwarden CLI), avoiding plaintext credentials in the repository."
@@ -3677,7 +3724,7 @@ msgstr ""
 "レットを取得し、リポジトリに平文の認証情報を含めることを避けています。"
 
 #. type: paragraph in src
-#: configuration.org:1953 .github/README.org:285
+#: configuration.org:1971 .github/README.org:285
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3686,7 +3733,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1957 .github/README.org:289
+#: configuration.org:1975 .github/README.org:289
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3716,35 +3763,35 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1983 .github/README.org:314
+#: configuration.org:2001 .github/README.org:314
 #, no-wrap
 msgid "Translation"
 msgstr "翻訳"
 
 #. type: paragraph
-#: configuration.org:1985 .github/README.org:316
+#: configuration.org:2003 .github/README.org:316
 msgid "This project uses po4a to manage translations."
 msgstr "このプロジェクトでは翻訳にpo4aを使っています。"
 
 #. type: heading ***
-#: configuration.org:1987 .github/README.org:317
+#: configuration.org:2005 .github/README.org:317
 #, no-wrap
 msgid "Requirements"
 msgstr "必要なソフトウェア"
 
 #. type: paragraph
-#: configuration.org:1989 .github/README.org:319
+#: configuration.org:2007 .github/README.org:319
 msgid "The required packages are included in the development shell."
 msgstr "必要なパッケージは開発シェルに含まれています。"
 
 #. type: keyword name
-#: configuration.org:1991 .github/README.org:321
+#: configuration.org:2009 .github/README.org:321
 #, no-wrap
 msgid "translation-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1993 .github/README.org:323
+#: configuration.org:2011 .github/README.org:323
 #, no-wrap
 msgid ""
 "gettext\n"
@@ -3752,31 +3799,31 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1998 .github/README.org:328
+#: configuration.org:2016 .github/README.org:328
 #, no-wrap
 msgid "=gettext=: provides msgfmt and other internationalization utilities"
 msgstr "=gettext=: msgfmtやその他の国際化ユーティリティを提供"
 
 #. type: plain list -
-#: configuration.org:1999 .github/README.org:329
+#: configuration.org:2017 .github/README.org:329
 #, no-wrap
 msgid "=po4a=: po4a >= 0.74 is required for Org mode support."
 msgstr "=po4a=: Org modeサポートにはpo4a >= 0.74が必要です。"
 
 #. type: heading ***
-#: configuration.org:2000 .github/README.org:329
+#: configuration.org:2018 .github/README.org:329
 #, no-wrap
 msgid "Translation workflow"
 msgstr "翻訳作業"
 
 #. type: heading ****
-#: configuration.org:2002 .github/README.org:331
+#: configuration.org:2020 .github/README.org:331
 #, no-wrap
 msgid "Create po4a configuration"
 msgstr "po4aを設定する"
 
 #. type: paragraph
-#: configuration.org:2004 .github/README.org:333
+#: configuration.org:2022 .github/README.org:333
 msgid ""
 "Configure the target language, location for generated po files, and "
 "documents to translate as follows.  The =-k 0= option forces output of "
@@ -3789,7 +3836,7 @@ msgstr ""
 "いるときのみ出力されます。)"
 
 #. type: paragraph in src
-#: configuration.org:2013 .github/README.org:342
+#: configuration.org:2031 .github/README.org:342
 #, no-wrap
 msgid ""
 "[po4a_langs] ja\n"
@@ -3803,19 +3850,19 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2023 .github/README.org:352
+#: configuration.org:2041 .github/README.org:352
 msgid ""
 "For detailed information about =po4a.cfg= configuration, see =man po4a=."
 msgstr "=po4a.cfg=について、詳しくは=man po4a=を参照してください。"
 
 #. type: heading ****
-#: configuration.org:2025 .github/README.org:353
+#: configuration.org:2043 .github/README.org:353
 #, no-wrap
 msgid "Create/Update po"
 msgstr "poを生成/更新する"
 
 #. type: paragraph
-#: configuration.org:2027 .github/README.org:355
+#: configuration.org:2045 .github/README.org:355
 msgid ""
 "When documents are updated and you need to create/update po files, run the "
 "following command.  This generates template (pot) and po files for each "
@@ -3826,19 +3873,19 @@ msgstr ""
 "に生成します。"
 
 #. type: paragraph in src
-#: configuration.org:2033 .github/README.org:361
+#: configuration.org:2051 .github/README.org:361
 #, no-wrap
 msgid "po4a --no-translations po4a.cfg"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:2036 .github/README.org:363
+#: configuration.org:2054 .github/README.org:363
 #, no-wrap
 msgid "Translate"
 msgstr "翻訳する"
 
 #. type: paragraph
-#: configuration.org:2038 .github/README.org:365
+#: configuration.org:2056 .github/README.org:365
 msgid ""
 "Edit the target language po using a po editor.  Popular options include "
 "Emacs po-mode, poedit, GNOME's Gtranslator, and KDE's Lokalize."
@@ -3847,13 +3894,13 @@ msgstr ""
 "Gtranslator、KDEのLokalizeが有名です。"
 
 #. type: heading ****
-#: configuration.org:2045 .github/README.org:371
+#: configuration.org:2063 .github/README.org:371
 #, no-wrap
 msgid "Create/Update translation file"
 msgstr "翻訳ファイルを生成/更新する"
 
 #. type: paragraph
-#: configuration.org:2047 .github/README.org:373
+#: configuration.org:2065 .github/README.org:373
 msgid ""
 "After completing translations, generate files with the following command.  "
 "Since po files are also updated at this time, in practice you only need to "
@@ -3863,7 +3910,7 @@ msgstr ""
 "め、実運用上はこのコマンドを実行するだけで良いでしょう。"
 
 #. type: paragraph in src
-#: configuration.org:2053 .github/README.org:379
+#: configuration.org:2071 .github/README.org:379
 #, no-wrap
 msgid "po4a po4a.cfg"
 msgstr ""
@@ -6669,10 +6716,10 @@ msgstr ""
 #. type: paragraph
 #: overlays/configuration.org:14
 msgid ""
-"Overlays are organized into four categories based on their purpose and "
+"Overlays are organized into five categories based on their purpose and "
 "expected lifetime:"
 msgstr ""
-"overlayは目的と想定される存続期間に基づいて4つのカテゴリに分類されています："
+"overlayは目的と想定される存続期間に基づいて5つのカテゴリに分類されています："
 
 #. type: plain list -
 #: overlays/configuration.org:18
@@ -6688,6 +6735,16 @@ msgstr ""
 #: overlays/configuration.org:20
 #, no-wrap
 msgid ""
+"*cuda*: Packages taken from the CUDA channel, the only revision whose CUDA builds are\n"
+"cached."
+msgstr ""
+"*cuda*: CUDAチャンネルから取得するパッケージ。CUDAのビルドがキャッシュされている\n"
+"唯一のリビジョン。"
+
+#. type: plain list -
+#: overlays/configuration.org:22
+#, no-wrap
+msgid ""
 "*temporary-fix*: Local overrides (e.g., disabling tests) that don't require a different\n"
 "nixpkgs version. Remove once fixed upstream."
 msgstr ""
@@ -6695,13 +6752,13 @@ msgstr ""
 "（例: テストの無効化）。アップストリームで修正されたら削除します。"
 
 #. type: plain list -
-#: overlays/configuration.org:21
+#: overlays/configuration.org:23
 #, no-wrap
 msgid "*pre-release*: Alpha, beta, or pre-release packages for testing before they land in nixpkgs."
 msgstr "*pre-release*: nixpkgsに入る前にテストするためのアルファ版、ベータ版、プレリリースパッケージ。"
 
 #. type: plain list -
-#: overlays/configuration.org:23
+#: overlays/configuration.org:25
 #, no-wrap
 msgid ""
 "*patches*: Workarounds not suitable for upstream contribution (e.g., locale-specific fixes,\n"
@@ -6711,7 +6768,7 @@ msgstr ""
 "ローカルツールのshim）。恒久的に残る想定です。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:30
+#: overlays/configuration.org:32
 #, no-wrap
 msgid ""
 "{ inputs }:\n"
@@ -6720,19 +6777,25 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:34
+#: overlays/configuration.org:36
+#, no-wrap
+msgid "<<cuda>>"
+msgstr ""
+
+#. type: paragraph in src
+#: overlays/configuration.org:38
 #, no-wrap
 msgid "<<temporary-fix>>"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:36
+#: overlays/configuration.org:40
 #, no-wrap
 msgid "<<pre-release>>"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:38
+#: overlays/configuration.org:42
 #, no-wrap
 msgid ""
 "  <<patches>>\n"
@@ -6740,13 +6803,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:42 overlays/configuration.org:48
+#: overlays/configuration.org:46 overlays/configuration.org:52
 #, no-wrap
 msgid "stable"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:44
+#: overlays/configuration.org:48
 msgid ""
 "Fetch packages from nixpkgs-stable when broken in unstable. This includes "
 "cases where the upstream fix would trigger excessive rebuilds, or where the "
@@ -6757,7 +6820,7 @@ msgstr ""
 "雑すぎる場合が該当します。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:50
+#: overlays/configuration.org:54
 #, no-wrap
 msgid ""
 "stable = final: prev: {\n"
@@ -6765,13 +6828,68 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:54 overlays/configuration.org:61
+#: overlays/configuration.org:58 overlays/configuration.org:68
+#, no-wrap
+msgid "cuda"
+msgstr ""
+
+#. type: paragraph
+#: overlays/configuration.org:60
+msgid ""
+"[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]] only covers the head "
+"of =nixos-unstable-cuda=, so kilimanjaro takes its CUDA packages from "
+"=nixpkgs-cuda=. Naming =ollama= and =handy= is enough: =onnxruntime=, "
+"=openvino=, =opencv= and =cudnn-frontend= are only reachable through them."
+msgstr ""
+"[[https://cache.nixos-cuda.org][cache.nixos-cuda.org]]は=nixos-unstable-cuda="
+"の先端しかカバーしていないため、kilimanjaroはCUDA関連パッケージを"
+"=nixpkgs-cuda=から取得します。=ollama=と=handy=を指定すれば十分で、"
+"=onnxruntime=、=openvino=、=opencv=、=cudnn-frontend=はこれらを経由してしか到"
+"達しません。"
+
+#. type: paragraph
+#: overlays/configuration.org:64
+msgid ""
+"The package set is imported plain because the CUDA Hydra builds plain "
+"nixpkgs, and a local overlay reaching into that closure would move the store "
+"paths off the cache. The guard keeps the pin off hosts that leave "
+"=cudaSupport= unset."
+msgstr ""
+"CUDAのHydraは素のnixpkgsをビルドしているため、このpackage setも素のまま"
+"importしています。ローカルのoverlayがそのクロージャに手を入れるとstore pathが"
+"変わり、キャッシュから外れてしまいます。ガードにより、=cudaSupport=を設定して"
+"いないホストにはこのピン留めが適用されません。"
+
+#. type: paragraph in src
+#: overlays/configuration.org:70
+#, no-wrap
+msgid ""
+"cuda =\n"
+"  final: prev:\n"
+"  prev.lib.optionalAttrs (prev.config.cudaSupport or false) (\n"
+"    let\n"
+"      pkgs = import inputs.nixpkgs-cuda {\n"
+"        inherit (prev.stdenv.hostPlatform) system;\n"
+"        config = {\n"
+"          cudaSupport = true;\n"
+"          allowUnfree = true;\n"
+"        };\n"
+"      };\n"
+"    in\n"
+"    {\n"
+"      inherit (pkgs) handy ollama;\n"
+"    }\n"
+"  );"
+msgstr ""
+
+#. type: keyword NAME
+#: overlays/configuration.org:88 overlays/configuration.org:95
 #, no-wrap
 msgid "temporary-fix"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:56
+#: overlays/configuration.org:90
 msgid ""
 "Local overrides for packages that build but have failing tests or minor "
 "issues.  Unlike the =stable= overlay, these don't require fetching packages "
@@ -6786,7 +6904,7 @@ msgstr ""
 "バーライドを削除します。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:63
+#: overlays/configuration.org:97
 #, no-wrap
 msgid ""
 "temporary-fix = final: prev: {\n"
@@ -6795,20 +6913,20 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: overlays/configuration.org:68
+#: overlays/configuration.org:102
 #, no-wrap
 msgid "Python313 package set"
 msgstr "Python313パッケージセット"
 
 #. type: paragraph
-#: overlays/configuration.org:70
+#: overlays/configuration.org:104
 msgid "Override problematic Python packages using =packageOverrides=."
 msgstr ""
 "=packageOverrides= を使用して問題のあるPythonパッケージをオーバーライドしま"
 "す。"
 
 #. type: paragraph
-#: overlays/configuration.org:72
+#: overlays/configuration.org:106
 msgid ""
 "Python packages in nixpkgs form an interconnected dependency graph. The "
 "=packageOverrides= mechanism ensures that when a package is overridden, all "
@@ -6825,7 +6943,7 @@ msgstr ""
 "バージョンを使い続けてしまいます。"
 
 #. type: paragraph
-#: overlays/configuration.org:78
+#: overlays/configuration.org:112
 msgid ""
 "See [[https://nixos.org/manual/nixpkgs/stable/#overriding-python-packages]"
 "[nixpkgs Python documentation]] for details."
@@ -6834,13 +6952,13 @@ msgstr ""
 "[nixpkgs Pythonドキュメント]]を参照してください。"
 
 #. type: keyword NAME
-#: overlays/configuration.org:80
+#: overlays/configuration.org:114
 #, no-wrap
 msgid "python313-package-set"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:82
+#: overlays/configuration.org:116
 #, no-wrap
 msgid ""
 "python313 = prev.python313.override {\n"
@@ -6852,13 +6970,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:90 overlays/configuration.org:98
+#: overlays/configuration.org:124 overlays/configuration.org:132
 #, no-wrap
 msgid "rapidocr-onnxruntime"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:92
+#: overlays/configuration.org:126
 msgid ""
 "The test suite causes a segmentation fault during execution. The root cause "
 "is still under investigation."
@@ -6867,7 +6985,7 @@ msgstr ""
 "まだ調査中です。"
 
 #. type: paragraph
-#: overlays/configuration.org:95
+#: overlays/configuration.org:129
 msgid ""
 "This package is pulled in as a transitive dependency. Runtime functionality "
 "has been verified to work correctly in actual use, so disabling the test "
@@ -6878,7 +6996,7 @@ msgstr ""
 "回避策です。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:100
+#: overlays/configuration.org:134
 #, no-wrap
 msgid ""
 "rapidocr-onnxruntime = pyprev.rapidocr-onnxruntime.overridePythonAttrs (_: {\n"
@@ -6887,13 +7005,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:105 overlays/configuration.org:114
+#: overlays/configuration.org:139 overlays/configuration.org:148
 #, no-wrap
 msgid "lxml-html-clean"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:107
+#: overlays/configuration.org:141
 msgid ""
 "Tests fail due to breaking changes in libxml2 2.14, which modified how "
 "certain DOM operations handle whitespace and entity encoding. These changes "
@@ -6906,7 +7024,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph
-#: overlays/configuration.org:111
+#: overlays/configuration.org:145
 msgid ""
 "Tracked upstream in [[https://github.com/fedora-python/lxml_html_clean/"
 "issues/24][fedora-python/lxml_html_clean#24]].  Remove this override once "
@@ -6917,7 +7035,7 @@ msgstr ""
 "トがlibxml2 2.14互換に更新されたらこのオーバーライドを削除します。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:116
+#: overlays/configuration.org:150
 #, no-wrap
 msgid ""
 "lxml-html-clean = pyprev.lxml-html-clean.overridePythonAttrs (_: {\n"
@@ -6926,13 +7044,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:121 overlays/configuration.org:127
+#: overlays/configuration.org:155 overlays/configuration.org:161
 #, no-wrap
 msgid "pre-release"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:123
+#: overlays/configuration.org:157
 msgid ""
 "Overlay for testing alpha, beta, or pre-release versions of packages before "
 "they land in nixpkgs. Useful for evaluating release candidates, nightly "
@@ -6945,24 +7063,24 @@ msgstr ""
 "除します。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:129
+#: overlays/configuration.org:163
 #, no-wrap
 msgid "pre-release = final: prev: { };"
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:132 overlays/configuration.org:141
+#: overlays/configuration.org:166 overlays/configuration.org:175
 #, no-wrap
 msgid "patches"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:134
+#: overlays/configuration.org:168
 msgid "Workarounds that are not suitable for upstream contribution."
 msgstr "アップストリームへの貢献に適さない回避策です。"
 
 #. type: paragraph
-#: overlays/configuration.org:136
+#: overlays/configuration.org:170
 msgid ""
 "These patches address issues that upstream would likely not accept—either "
 "because they are specific to this configuration (e.g., locale settings), "
@@ -6975,7 +7093,7 @@ msgstr ""
 "久的に残る想定です。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:143
+#: overlays/configuration.org:177
 #, no-wrap
 msgid ""
 "patches = final: prev: {\n"
@@ -6985,13 +7103,13 @@ msgid ""
 msgstr ""
 
 #. type: keyword NAME
-#: overlays/configuration.org:149 overlays/configuration.org:162
+#: overlays/configuration.org:183 overlays/configuration.org:196
 #, no-wrap
 msgid "gh-dash"
 msgstr ""
 
 #. type: paragraph
-#: overlays/configuration.org:151
+#: overlays/configuration.org:185
 msgid ""
 "The preview pane renders incorrectly when =LANG=ja_JP.UTF-8= is set. The "
 "issue stems from gh-dash's terminal width calculation, which miscounts the "
@@ -7004,7 +7122,7 @@ msgstr ""
 "す。"
 
 #. type: paragraph
-#: overlays/configuration.org:156
+#: overlays/configuration.org:190
 msgid ""
 "Setting =LANG=C.UTF-8= forces ASCII-compatible width calculations while "
 "preserving UTF-8 encoding support, which fixes the rendering issue. We use "
@@ -7017,7 +7135,7 @@ msgstr ""
 "います。"
 
 #. type: paragraph
-#: overlays/configuration.org:160
+#: overlays/configuration.org:194
 msgid ""
 "Reported upstream in [[https://github.com/dlvhdr/gh-dash/issues/316][dlvhdr/"
 "gh-dash#316]]."
@@ -7026,7 +7144,7 @@ msgstr ""
 "gh-dash#316]]で報告済みです。"
 
 #. type: paragraph in src
-#: overlays/configuration.org:164
+#: overlays/configuration.org:198
 #, no-wrap
 msgid ""
 "gh-dash =\n"
@@ -7040,19 +7158,19 @@ msgid ""
 msgstr ""
 
 #. type: heading ***
-#: overlays/configuration.org:174
+#: overlays/configuration.org:208
 #, no-wrap
 msgid "mkShim"
 msgstr "mkShim"
 
 #. type: paragraph
-#: overlays/configuration.org:176
+#: overlays/configuration.org:210
 msgid ""
 "Shim utility for providing stub implementations of macOS Command Line Tools."
 msgstr "macOS Command Line Toolsのスタブ実装を提供するshimユーティリティです。"
 
 #. type: paragraph
-#: overlays/configuration.org:178
+#: overlays/configuration.org:212
 msgid ""
 "On darwin systems without Xcode Command Line Tools installed, invoking "
 "commands like =cc= or =python3= triggers an annoying system popup prompting "
@@ -7067,7 +7185,7 @@ msgstr ""
 "制し不要なビルド失敗を防ぎます。"
 
 #. type: paragraph
-#: overlays/configuration.org:183
+#: overlays/configuration.org:217
 msgid ""
 "See [[file:../pkgs/mkShim/][pkgs/mkShim]] for the implementation details and "
 "list of shimmed commands."
@@ -7076,13 +7194,13 @@ msgstr ""
 "mkShim]]を参照してください。"
 
 #. type: keyword NAME
-#: overlays/configuration.org:185
+#: overlays/configuration.org:219
 #, no-wrap
 msgid "command-line-tools-shim"
 msgstr ""
 
 #. type: paragraph in src
-#: overlays/configuration.org:187
+#: overlays/configuration.org:221
 #, no-wrap
 msgid "inherit (final.callPackage ../pkgs/mkShim { }) mkShim commandLineToolsShim;"
 msgstr ""


### PR DESCRIPTION
## Summary

Bumps every flake input. Two of them cannot simply track their upstream branch, so they are pinned and documented.

`nixpkgs` reaches the current `nixos-unstable-small` head (`328e42b4`). An earlier snapshot broke evaluation via home-manager, but upstream reverted the cause (`ec69cf3f7b86`, revert of `nixos/modular-services: add portable process.environment`), so no hold-back is needed.

## nixpkgs-cuda

kilimanjaro builds with `cudaSupport`, and only `cache.nixos-cuda.org` carries those builds, for the head of `nixos-unstable-cuda` alone. Past that revision `ollama` and `handy` fall out of the cache and cannot be rebuilt locally either — `cudnn-frontend` fails in its CMake lookup for the CUDA toolkit.

The new `cuda` overlay takes those two from a second package set pinned to that branch. Its whole CUDA subtree hangs off exactly two roots, so naming them is enough:

```
ollama
handy -> onnxruntime -> openvino -> opencv
                     -> cudnn-frontend
```

The set is imported plain (`cudaSupport` + `allowUnfree` only) because the CUDA Hydra builds plain nixpkgs; the resulting store paths match what the cache holds. An `optionalAttrs` guard keeps the pin off every host that leaves `cudaSupport` unset.

| host | ollama |
| --- | --- |
| kilimanjaro | 0.31.1 (CUDA revision) |
| manyara | 0.32.1 (main input) |
| work (darwin) | 0.32.1 (main input) |

## hermes-agent

Upstream reads `package.json`, `pyproject.toml` and `uv.lock` out of `builtins.path` copies that only materialise under a writable store, so the read-only evaluation CI runs fails:

```
error: path 'jdj5zkdhhj14g773iacykrg5s0lah77d-hermes-python-source' is not valid
```

Tracking the fork branch until NousResearch/hermes-agent#71228 merges; the revert condition is recorded in `configuration.org`.

## Verification

| check | result |
| --- | --- |
| `nix flake check --no-build --all-systems` | pass |
| x86_64-linux (arusha, kilimanjaro, manyara, devShell) | pass |
| aarch64-linux (serengeti, nix-on-droid, devShell) | pass |
| aarch64-darwin (katavi, mikumi, work, devShell) | pass |