### PR TITLE
feat(infra): add an R2 bucket for restic repositories

### DIFF
--- a/infra/global/domains/natsukium-com/main.tf
+++ b/infra/global/domains/natsukium-com/main.tf
@@ -115,6 +115,11 @@ resource "cloudflare_r2_bucket" "nix_cache_niks3" {
   name       = "nix-cache-niks3"
 }
 
+resource "cloudflare_r2_bucket" "restic_backup" {
+  account_id = local.cloudflare_account_id
+  name       = "restic-backup"
+}
+
 # Public read path: clients pull straight from R2 (CDN-cached), bypassing the
 # tunnel. Cloudflare manages this DNS record itself, hence not in local.records.
 resource "cloudflare_r2_custom_domain" "nix_cache_niks3" {


### PR DESCRIPTION
First step toward off-site backups for manyara's services (forgejo,
miniflux, home-assistant, continuwuity), which have no off-site copy
today. Only the bucket here; the NixOS side follows separately.

Named `restic-backup` rather than something generic: bucket names are
account-wide, and nothing but restic can read what goes in it.

After merge, two things still have to happen by hand before the NixOS
side is useful:

- mint an R2 API token scoped to this bucket with Object Read & Write —
  the Cloudflare provider cannot create account API tokens
- seed the repository password and those credentials into sops