### PR TITLE
build: build the flake's checks instead of a hand-listed attribute set

### DIFF
--- a/.github/README.org
+++ b/.github/README.org
@@ -67,6 +67,10 @@ translation tools (po4a, gettext), and build utilities (nix-fast-build).
 On entry, it automatically sets up pre-commit hooks, configures MCP servers,
 and syncs =CLAUDE.md= from the literate source.
 
+The shell is exposed as a check as well. The build target walks the flake's
+checks, so a tool that stops building fails there instead of on the next
+=nix develop=.
+
 #+begin_src nix :tangle modules/per-system/dev-shell.nix
 { ... }:
 {
@@ -112,6 +116,8 @@ and syncs =CLAUDE.md= from the literate source.
           packages = [ terraform' ];
         };
       };
+
+      checks.devShell = config.devShells.default;
     };
 }
 #+end_src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,5 @@ jobs:
       - name: build
         if: needs.check.result == 'success'
         run: |
-          export MAKEFLAGS="NIX:=nix"
-          make build
+          nix shell nixpkgs#nix-fast-build --inputs-from . --command make build
           df -h

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ attmcojp-claude-md-seal:
 # Nix build
 #──────────────────────────────────────────────
 
-NIX := nom
+NIX_FAST_BUILD := nix-fast-build --skip-cached
 
 OS   := $(shell uname -s)
 ARCH := $(shell uname -m)
@@ -100,31 +100,9 @@ endif
 
 build: $(SYSTEM)
 
-ATTRS_x86_64-linux := \
-	.\#nixosConfigurations.arusha.config.system.build.toplevel \
-	.\#nixosConfigurations.kilimanjaro.config.system.build.toplevel \
-	.\#nixosConfigurations.manyara.config.system.build.toplevel \
-	.\#devShells.x86_64-linux.default
-
-ATTRS_aarch64-linux := \
-	.\#nixosConfigurations.serengeti.config.system.build.toplevel \
-	.\#nixOnDroidConfigurations.default.config.environment.path \
-	.\#devShells.aarch64-linux.default
-
-ATTRS_aarch64-darwin := \
-	.\#darwinConfigurations.katavi.system \
-	.\#darwinConfigurations.mikumi.system \
-	.\#darwinConfigurations.work.system \
-	.\#devShells.aarch64-darwin.default
-
-# $(1) is the --eval-system value, left empty to evaluate as the host system.
-define nix-build
-	$(NIX) build --keep-going --no-link --show-trace --print-out-paths \
-		$(if $(1),--eval-system $(1)) $(2)
-endef
-
 x86_64-linux aarch64-linux aarch64-darwin:
-	$(call nix-build,$@,$(ATTRS_$@))
+	$(NIX_FAST_BUILD) --flake '.#checks.$@'
 
 build-all:
-	$(call nix-build,,$(ATTRS_x86_64-linux) $(ATTRS_aarch64-linux) $(ATTRS_aarch64-darwin))
+	$(NIX_FAST_BUILD) --flake '.#checks' \
+		--systems "x86_64-linux aarch64-linux aarch64-darwin"

--- a/configuration.org
+++ b/configuration.org
@@ -1676,6 +1676,10 @@ translation tools (po4a, gettext), and build utilities (nix-fast-build).
 On entry, it automatically sets up pre-commit hooks, configures MCP servers,
 and syncs =CLAUDE.md= from the literate source.
 
+The shell is exposed as a check as well. The build target walks the flake's
+checks, so a tool that stops building fails there instead of on the next
+=nix develop=.
+
 #+begin_src nix :tangle modules/per-system/dev-shell.nix
 { ... }:
 {
@@ -1721,6 +1725,8 @@ and syncs =CLAUDE.md= from the literate source.
           packages = [ terraform' ];
         };
       };
+
+      checks.devShell = config.devShells.default;
     };
 }
 #+end_src

--- a/modules/hosts.nix
+++ b/modules/hosts.nix
@@ -56,6 +56,11 @@ in
             nixosConfigurations // darwinConfigurations
           );
         in
-        builtins.mapAttrs (_: v: v.config.system.build.toplevel) current;
+        builtins.mapAttrs (_: v: v.config.system.build.toplevel) current
+        // lib.optionalAttrs (system == "aarch64-linux") {
+          # nix-on-droid has no toplevel, so the environment path stands in as the
+          # closest buildable equivalent.
+          android = nixOnDroidConfigurations.default.config.environment.path;
+        };
     };
 }

--- a/modules/per-system/dev-shell.nix
+++ b/modules/per-system/dev-shell.nix
@@ -43,5 +43,7 @@
           packages = [ terraform' ];
         };
       };
+
+      checks.devShell = config.devShells.default;
     };
 }

--- a/po/dotfiles.pot
+++ b/po/dotfiles.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-08-29 15:56+0900\n"
+"POT-Creation-Date: 2026-08-30 00:55+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3220,8 +3220,16 @@ msgid ""
 "and syncs =CLAUDE.md= from the literate source."
 msgstr ""
 
+#. type: paragraph
+#: configuration.org:1679 .github/README.org:70
+msgid ""
+"The shell is exposed as a check as well. The build target walks the flake's "
+"checks, so a tool that stops building fails there instead of on the next "
+"=nix develop=."
+msgstr ""
+
 #. type: paragraph in src
-#: configuration.org:1680 .github/README.org:71
+#: configuration.org:1684 .github/README.org:75
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -3267,25 +3275,32 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1720 .github/README.org:111
+#: configuration.org:1724 .github/README.org:115
 #, no-wrap
 msgid ""
-"        terraform = pkgs.mkShell {\n"
-"          packages = [ terraform' ];\n"
-"        };\n"
-"      };\n"
+"  terraform = pkgs.mkShell {\n"
+"    packages = [ terraform' ];\n"
+"  };\n"
+"};"
+msgstr ""
+
+#. type: paragraph in src
+#: configuration.org:1729 .github/README.org:120
+#, no-wrap
+msgid ""
+"      checks.devShell = config.devShells.default;\n"
 "    };\n"
 "}"
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1728 .github/README.org:118
+#: configuration.org:1734 .github/README.org:124
 #, no-wrap
 msgid "Pre-commit hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1730 .github/README.org:120
+#: configuration.org:1736 .github/README.org:126
 msgid ""
 "Hooks run by [[https://github.com/cachix/git-hooks.nix][git-hooks.nix]] on "
 "every commit. =prek= is used as the runner because it is the "
@@ -3294,7 +3309,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1734 .github/README.org:124
+#: configuration.org:1740 .github/README.org:130
 msgid ""
 "=check-org-tangle= is the only hook with =priority = 0= because it must run "
 "before everything else: if Org files are out of sync, formatters and linters "
@@ -3303,7 +3318,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1740 .github/README.org:130
+#: configuration.org:1746 .github/README.org:136
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3312,7 +3327,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1744 .github/README.org:134
+#: configuration.org:1750 .github/README.org:140
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -3434,13 +3449,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1858 .github/README.org:247
+#: configuration.org:1864 .github/README.org:253
 #, no-wrap
 msgid "Formatting"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1860 .github/README.org:249
+#: configuration.org:1866 .github/README.org:255
 msgid ""
 "Formatters are aggregated via "
 "[[https://github.com/numtide/treefmt-nix][treefmt-nix]] and invoked from the "
@@ -3449,7 +3464,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1865 .github/README.org:254
+#: configuration.org:1871 .github/README.org:260
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3458,7 +3473,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1869 .github/README.org:258
+#: configuration.org:1875 .github/README.org:264
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3483,13 +3498,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1891 .github/README.org:279
+#: configuration.org:1897 .github/README.org:285
 #, no-wrap
 msgid "MCP Servers"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1893 .github/README.org:281
+#: configuration.org:1899 .github/README.org:287
 msgid ""
 "Configuration for "
 "[[https://github.com/natsukium/mcp-servers-nix][mcp-servers-nix]], enabled "
@@ -3498,19 +3513,19 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1899 .github/README.org:287
+#: configuration.org:1905 .github/README.org:293
 #, no-wrap
 msgid "=nixos=: NixOS package/option search and Home Manager documentation"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1900 .github/README.org:288
+#: configuration.org:1906 .github/README.org:294
 #, no-wrap
 msgid "=terraform=: Terraform registry lookup for providers, modules, and policies"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1901 .github/README.org:289
+#: configuration.org:1907 .github/README.org:295
 #, no-wrap
 msgid ""
 "=grafana=: Query dashboards, datasources, and metrics from the home server's "
@@ -3518,19 +3533,19 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1897 .github/README.org:285
+#: configuration.org:1903 .github/README.org:291
 msgid "Enabled servers:"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1902 .github/README.org:290
+#: configuration.org:1908 .github/README.org:296
 msgid ""
 "The =passwordCommand= option retrieves secrets at runtime using =rbw= "
 "(Bitwarden CLI), avoiding plaintext credentials in the repository."
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1906 .github/README.org:294
+#: configuration.org:1912 .github/README.org:300
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3539,7 +3554,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1910 .github/README.org:298
+#: configuration.org:1916 .github/README.org:304
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3569,35 +3584,35 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1936 .github/README.org:323
+#: configuration.org:1942 .github/README.org:329
 #, no-wrap
 msgid "Translation"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1938 .github/README.org:325
+#: configuration.org:1944 .github/README.org:331
 msgid "This project uses po4a to manage translations."
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1940 .github/README.org:326
+#: configuration.org:1946 .github/README.org:332
 #, no-wrap
 msgid "Requirements"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1942 .github/README.org:328
+#: configuration.org:1948 .github/README.org:334
 msgid "The required packages are included in the development shell."
 msgstr ""
 
 #. type: keyword name
-#: configuration.org:1944 .github/README.org:330
+#: configuration.org:1950 .github/README.org:336
 #, no-wrap
 msgid "translation-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1946 .github/README.org:332
+#: configuration.org:1952 .github/README.org:338
 #, no-wrap
 msgid ""
 "gettext\n"
@@ -3605,31 +3620,31 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1951 .github/README.org:337
+#: configuration.org:1957 .github/README.org:343
 #, no-wrap
 msgid "=gettext=: provides msgfmt and other internationalization utilities"
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1952 .github/README.org:338
+#: configuration.org:1958 .github/README.org:344
 #, no-wrap
 msgid "=po4a=: po4a >= 0.74 is required for Org mode support."
 msgstr ""
 
 #. type: heading ***
-#: configuration.org:1953 .github/README.org:338
+#: configuration.org:1959 .github/README.org:344
 #, no-wrap
 msgid "Translation workflow"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1955 .github/README.org:340
+#: configuration.org:1961 .github/README.org:346
 #, no-wrap
 msgid "Create po4a configuration"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1957 .github/README.org:342
+#: configuration.org:1963 .github/README.org:348
 msgid ""
 "Configure the target language, location for generated po files, and "
 "documents to translate as follows.  The =-k 0= option forces output of "
@@ -3638,7 +3653,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1966 .github/README.org:351
+#: configuration.org:1972 .github/README.org:357
 #, no-wrap
 msgid ""
 "[po4a_langs] ja\n"
@@ -3656,18 +3671,18 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1976 .github/README.org:361
+#: configuration.org:1982 .github/README.org:367
 msgid "For detailed information about =po4a.cfg= configuration, see =man po4a=."
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1978 .github/README.org:362
+#: configuration.org:1984 .github/README.org:368
 #, no-wrap
 msgid "Create/Update po"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1980 .github/README.org:364
+#: configuration.org:1986 .github/README.org:370
 msgid ""
 "When documents are updated and you need to create/update po files, run the "
 "following command.  This generates template (pot) and po files for each "
@@ -3675,32 +3690,32 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1986 .github/README.org:370
+#: configuration.org:1992 .github/README.org:376
 #, no-wrap
 msgid "po4a --no-translations po4a.cfg"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1989 .github/README.org:372
+#: configuration.org:1995 .github/README.org:378
 #, no-wrap
 msgid "Translate"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1991 .github/README.org:374
+#: configuration.org:1997 .github/README.org:380
 msgid ""
 "Edit the target language po using a po editor.  Popular options include "
 "Emacs po-mode, poedit, GNOME's Gtranslator, and KDE's Lokalize."
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1998 .github/README.org:380
+#: configuration.org:2004 .github/README.org:386
 #, no-wrap
 msgid "Create/Update translation file"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:2000 .github/README.org:382
+#: configuration.org:2006 .github/README.org:388
 msgid ""
 "After completing translations, generate files with the following command.  "
 "Since po files are also updated at this time, in practice you only need to "
@@ -3708,7 +3723,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:2006 .github/README.org:388
+#: configuration.org:2012 .github/README.org:394
 #, no-wrap
 msgid "po4a po4a.cfg"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-08-29 15:56+0900\n"
+"POT-Creation-Date: 2026-08-30 00:55+0900\n"
 "PO-Revision-Date: 2026-03-01 14:13+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -3291,8 +3291,16 @@ msgstr ""
 "シェルに入ると自動的にpre-commitフックのセットアップ、MCPサーバーの設定、文芸"
 "的ソースからの =CLAUDE.md= 同期が行われます。"
 
+#. type: paragraph
+#: configuration.org:1679 .github/README.org:70
+msgid ""
+"The shell is exposed as a check as well. The build target walks the flake's "
+"checks, so a tool that stops building fails there instead of on the next "
+"=nix develop=."
+msgstr ""
+
 #. type: paragraph in src
-#: configuration.org:1680 .github/README.org:71
+#: configuration.org:1684 .github/README.org:75
 #, no-wrap
 msgid ""
 "{ ... }:\n"
@@ -3337,25 +3345,32 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1720 .github/README.org:111
+#: configuration.org:1724 .github/README.org:115
 #, no-wrap
 msgid ""
-"        terraform = pkgs.mkShell {\n"
-"          packages = [ terraform' ];\n"
-"        };\n"
-"      };\n"
+"  terraform = pkgs.mkShell {\n"
+"    packages = [ terraform' ];\n"
+"  };\n"
+"};"
+msgstr ""
+
+#. type: paragraph in src
+#: configuration.org:1729 .github/README.org:120
+#, no-wrap
+msgid ""
+"      checks.devShell = config.devShells.default;\n"
 "    };\n"
 "}"
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1728 .github/README.org:118
+#: configuration.org:1734 .github/README.org:124
 #, no-wrap
 msgid "Pre-commit hooks"
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1730 .github/README.org:120
+#: configuration.org:1736 .github/README.org:126
 msgid ""
 "Hooks run by [[https://github.com/cachix/git-hooks.nix][git-hooks.nix]] on "
 "every commit. =prek= is used as the runner because it is the actively-"
@@ -3364,7 +3379,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1734 .github/README.org:124
+#: configuration.org:1740 .github/README.org:130
 msgid ""
 "=check-org-tangle= is the only hook with =priority = 0= because it must run "
 "before everything else: if Org files are out of sync, formatters and linters "
@@ -3373,7 +3388,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1740 .github/README.org:130
+#: configuration.org:1746 .github/README.org:136
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3382,7 +3397,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1744 .github/README.org:134
+#: configuration.org:1750 .github/README.org:140
 #, no-wrap
 msgid ""
 "  perSystem =\n"
@@ -3499,14 +3514,14 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1858 .github/README.org:247
+#: configuration.org:1864 .github/README.org:253
 #, fuzzy, no-wrap
 #| msgid "Core Settings"
 msgid "Formatting"
 msgstr "コア設定"
 
 #. type: paragraph
-#: configuration.org:1860 .github/README.org:249
+#: configuration.org:1866 .github/README.org:255
 msgid ""
 "Formatters are aggregated via [[https://github.com/numtide/treefmt-nix]"
 "[treefmt-nix]] and invoked from the =treefmt= pre-commit hook, so a single "
@@ -3514,7 +3529,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1865 .github/README.org:254
+#: configuration.org:1871 .github/README.org:260
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3523,7 +3538,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1869 .github/README.org:258
+#: configuration.org:1875 .github/README.org:264
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3548,13 +3563,13 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1891 .github/README.org:279
+#: configuration.org:1897 .github/README.org:285
 #, no-wrap
 msgid "MCP Servers"
 msgstr "MCPサーバー"
 
 #. type: paragraph
-#: configuration.org:1893 .github/README.org:281
+#: configuration.org:1899 .github/README.org:287
 msgid ""
 "Configuration for [[https://github.com/natsukium/mcp-servers-nix][mcp-"
 "servers-nix]], enabled in the development shell.  The =flavors.claude-code= "
@@ -3566,30 +3581,30 @@ msgstr ""
 "の期待するフォーマットと互換性のある =.mcp.json= ファイルが生成されます。"
 
 #. type: plain list -
-#: configuration.org:1899 .github/README.org:287
+#: configuration.org:1905 .github/README.org:293
 #, no-wrap
 msgid "=nixos=: NixOS package/option search and Home Manager documentation"
 msgstr "=nixos=: NixOSパッケージ/オプション検索とHome Managerのドキュメント"
 
 #. type: plain list -
-#: configuration.org:1900 .github/README.org:288
+#: configuration.org:1906 .github/README.org:294
 #, no-wrap
 msgid "=terraform=: Terraform registry lookup for providers, modules, and policies"
 msgstr "=terraform=: Terraformレジストリのプロバイダー、モジュール、ポリシー検索"
 
 #. type: plain list -
-#: configuration.org:1901 .github/README.org:289
+#: configuration.org:1907 .github/README.org:295
 #, no-wrap
 msgid "=grafana=: Query dashboards, datasources, and metrics from the home server's Grafana instance"
 msgstr "=grafana=: ホームサーバーのGrafanaインスタンスからダッシュボード、データソース、メトリクスを照会"
 
 #. type: paragraph
-#: configuration.org:1897 .github/README.org:285
+#: configuration.org:1903 .github/README.org:291
 msgid "Enabled servers:"
 msgstr "有効なサーバー："
 
 #. type: paragraph
-#: configuration.org:1902 .github/README.org:290
+#: configuration.org:1908 .github/README.org:296
 msgid ""
 "The =passwordCommand= option retrieves secrets at runtime using =rbw= "
 "(Bitwarden CLI), avoiding plaintext credentials in the repository."
@@ -3598,7 +3613,7 @@ msgstr ""
 "レットを取得し、リポジトリに平文の認証情報を含めることを避けています。"
 
 #. type: paragraph in src
-#: configuration.org:1906 .github/README.org:294
+#: configuration.org:1912 .github/README.org:300
 #, no-wrap
 msgid ""
 "{ inputs, ... }:\n"
@@ -3607,7 +3622,7 @@ msgid ""
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1910 .github/README.org:298
+#: configuration.org:1916 .github/README.org:304
 #, no-wrap
 msgid ""
 "  perSystem = _: {\n"
@@ -3637,35 +3652,35 @@ msgid ""
 msgstr ""
 
 #. type: heading **
-#: configuration.org:1936 .github/README.org:323
+#: configuration.org:1942 .github/README.org:329
 #, no-wrap
 msgid "Translation"
 msgstr "翻訳"
 
 #. type: paragraph
-#: configuration.org:1938 .github/README.org:325
+#: configuration.org:1944 .github/README.org:331
 msgid "This project uses po4a to manage translations."
 msgstr "このプロジェクトでは翻訳にpo4aを使っています。"
 
 #. type: heading ***
-#: configuration.org:1940 .github/README.org:326
+#: configuration.org:1946 .github/README.org:332
 #, no-wrap
 msgid "Requirements"
 msgstr "必要なソフトウェア"
 
 #. type: paragraph
-#: configuration.org:1942 .github/README.org:328
+#: configuration.org:1948 .github/README.org:334
 msgid "The required packages are included in the development shell."
 msgstr "必要なパッケージは開発シェルに含まれています。"
 
 #. type: keyword name
-#: configuration.org:1944 .github/README.org:330
+#: configuration.org:1950 .github/README.org:336
 #, no-wrap
 msgid "translation-packages"
 msgstr ""
 
 #. type: paragraph in src
-#: configuration.org:1946 .github/README.org:332
+#: configuration.org:1952 .github/README.org:338
 #, no-wrap
 msgid ""
 "gettext\n"
@@ -3673,31 +3688,31 @@ msgid ""
 msgstr ""
 
 #. type: plain list -
-#: configuration.org:1951 .github/README.org:337
+#: configuration.org:1957 .github/README.org:343
 #, no-wrap
 msgid "=gettext=: provides msgfmt and other internationalization utilities"
 msgstr "=gettext=: msgfmtやその他の国際化ユーティリティを提供"
 
 #. type: plain list -
-#: configuration.org:1952 .github/README.org:338
+#: configuration.org:1958 .github/README.org:344
 #, no-wrap
 msgid "=po4a=: po4a >= 0.74 is required for Org mode support."
 msgstr "=po4a=: Org modeサポートにはpo4a >= 0.74が必要です。"
 
 #. type: heading ***
-#: configuration.org:1953 .github/README.org:338
+#: configuration.org:1959 .github/README.org:344
 #, no-wrap
 msgid "Translation workflow"
 msgstr "翻訳作業"
 
 #. type: heading ****
-#: configuration.org:1955 .github/README.org:340
+#: configuration.org:1961 .github/README.org:346
 #, no-wrap
 msgid "Create po4a configuration"
 msgstr "po4aを設定する"
 
 #. type: paragraph
-#: configuration.org:1957 .github/README.org:342
+#: configuration.org:1963 .github/README.org:348
 msgid ""
 "Configure the target language, location for generated po files, and "
 "documents to translate as follows.  The =-k 0= option forces output of "
@@ -3710,7 +3725,7 @@ msgstr ""
 "いるときのみ出力されます。)"
 
 #. type: paragraph in src
-#: configuration.org:1966 .github/README.org:351
+#: configuration.org:1972 .github/README.org:357
 #, no-wrap
 msgid ""
 "[po4a_langs] ja\n"
@@ -3724,19 +3739,19 @@ msgid ""
 msgstr ""
 
 #. type: paragraph
-#: configuration.org:1976 .github/README.org:361
+#: configuration.org:1982 .github/README.org:367
 msgid ""
 "For detailed information about =po4a.cfg= configuration, see =man po4a=."
 msgstr "=po4a.cfg=について、詳しくは=man po4a=を参照してください。"
 
 #. type: heading ****
-#: configuration.org:1978 .github/README.org:362
+#: configuration.org:1984 .github/README.org:368
 #, no-wrap
 msgid "Create/Update po"
 msgstr "poを生成/更新する"
 
 #. type: paragraph
-#: configuration.org:1980 .github/README.org:364
+#: configuration.org:1986 .github/README.org:370
 msgid ""
 "When documents are updated and you need to create/update po files, run the "
 "following command.  This generates template (pot) and po files for each "
@@ -3747,19 +3762,19 @@ msgstr ""
 "に生成します。"
 
 #. type: paragraph in src
-#: configuration.org:1986 .github/README.org:370
+#: configuration.org:1992 .github/README.org:376
 #, no-wrap
 msgid "po4a --no-translations po4a.cfg"
 msgstr ""
 
 #. type: heading ****
-#: configuration.org:1989 .github/README.org:372
+#: configuration.org:1995 .github/README.org:378
 #, no-wrap
 msgid "Translate"
 msgstr "翻訳する"
 
 #. type: paragraph
-#: configuration.org:1991 .github/README.org:374
+#: configuration.org:1997 .github/README.org:380
 msgid ""
 "Edit the target language po using a po editor.  Popular options include "
 "Emacs po-mode, poedit, GNOME's Gtranslator, and KDE's Lokalize."
@@ -3768,13 +3783,13 @@ msgstr ""
 "Gtranslator、KDEのLokalizeが有名です。"
 
 #. type: heading ****
-#: configuration.org:1998 .github/README.org:380
+#: configuration.org:2004 .github/README.org:386
 #, no-wrap
 msgid "Create/Update translation file"
 msgstr "翻訳ファイルを生成/更新する"
 
 #. type: paragraph
-#: configuration.org:2000 .github/README.org:382
+#: configuration.org:2006 .github/README.org:388
 msgid ""
 "After completing translations, generate files with the following command.  "
 "Since po files are also updated at this time, in practice you only need to "
@@ -3784,7 +3799,7 @@ msgstr ""
 "め、実運用上はこのコマンドを実行するだけで良いでしょう。"
 
 #. type: paragraph in src
-#: configuration.org:2006 .github/README.org:388
+#: configuration.org:2012 .github/README.org:394
 #, no-wrap
 msgid "po4a po4a.cfg"
 msgstr ""


### PR DESCRIPTION
The Makefile kept its own list of host attributes per system, so every host added or removed meant editing it. The checks output already enumerates the hosts, so the build target walks that and the list lives in one place. The devShell and nix-on-droid join the checks so nothing that used to be built drops out.

nix-fast-build --skip-cached replaces nom. It takes the system set as an argument and skips what the cache already has, so the workflow no longer needs to override NIX to get a plain builder.

Assisted-by: Claude Code:Opus 5