### PR TITLE
fix(forgejo-runner): provide GNU tar with hiPrio over busybox

### DIFF
--- a/modules/configuration.org
+++ b/modules/configuration.org
@@ -3105,6 +3105,7 @@ nixosWrapper =
           [
             bash
             busybox
+            (hiPrio gnutar)
             curl
             git
             nix

--- a/modules/configuration.org
+++ b/modules/configuration.org
@@ -3104,8 +3104,8 @@ nixosWrapper =
           with pkgs;
           [
             bash
+            (lib.hiPrio gnutar)
             busybox
-            (hiPrio gnutar)
             curl
             git
             nix

--- a/modules/features/forgejo-runner/default.nix
+++ b/modules/features/forgejo-runner/default.nix
@@ -99,6 +99,7 @@ let
             [
               bash
               busybox
+              (hiPrio gnutar)
               curl
               git
               nix

--- a/modules/features/forgejo-runner/default.nix
+++ b/modules/features/forgejo-runner/default.nix
@@ -98,8 +98,8 @@ let
             with pkgs;
             [
               bash
+              (lib.hiPrio gnutar)
               busybox
-              (hiPrio gnutar)
               curl
               git
               nix


### PR DESCRIPTION
BusyBox `tar` lacks `--posix` which `Swatinem/rust-cache` / `actions/cache` require to save the cargo cache. The `nix` runner's `hostPackages` exposed only busybox's `tar`, so every cache save failed with:

```
tar: unrecognized option '--posix'
Failed to save: tar exit code 1
```

Seen in `natsukium/felis#57` logs. The per-runner internal cache (`cache.enabled=true` on kilimanjaro) never stored anything, so `cargo build`/`clippy`/`nextest` stayed cold.

Add `gnutar` with `hiPrio` so GNU tar shadows busybox's `tar` on `PATH`. Both provide `bin/tar`, so priority matters.

* `modules/configuration.org` (source) + tangle `modules/features/forgejo-runner/default.nix`
* Follow-up in `felis` will re-enable `Swatinem/rust-cache` with `cmd-format: "nix develop -c {0}"` once this hosts fix lands (currently using a `GITHUB_PATH` workaround with `nixpkgs#gnutar`).

Test: after deploy to kilimanjaro, `tar --version` on a `nix:host` job should report `GNU tar 1.35` and `Swatinem/rust-cache` post should show `Cache saved` instead of `Failed to save`.